### PR TITLE
Fixes error thrown in PostMostRecentCrash when Crash folder doesn't exist

### DIFF
--- a/Runtime/Reporter/WindowsReporter.cs
+++ b/Runtime/Reporter/WindowsReporter.cs
@@ -125,8 +125,14 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator PostMostRecentCrash(IReportPostOptions options = null, Action<HttpResponseMessage> callback = null)
         {
-            var folder = DirectoryInfoFactory.CreateDirectoryInfo(CrashReporting.crashReportFolder);
-            var crashFolder = folder.GetDirectories()
+            var unityCrashesFolder = DirectoryInfoFactory.CreateDirectoryInfo(CrashReporting.crashReportFolder);
+            if (!unityCrashesFolder.Exists)
+            {
+                Debug.Log($"BugSplat info: unity crash folder {unityCrashesFolder.Name} was not found");
+                yield break;
+            }
+
+            var crashFolder = unityCrashesFolder.GetDirectories()
                 .OrderByDescending(dir => dir.LastWriteTime)
                 .FirstOrDefault();
 

--- a/Runtime/Reporter/WindowsReporter.cs
+++ b/Runtime/Reporter/WindowsReporter.cs
@@ -26,6 +26,8 @@ namespace BugSplatUnity.Runtime.Reporter
         private readonly IExceptionReporter _exceptionReporter;
         private readonly INativeCrashReportClient _nativeCrashReportClient;
 
+        private readonly string noCrashFolderFoundString = "BugSplat info: unity crash folder {0} was not found";
+
         public WindowsReporter(
             IClientSettingsRepository clientSettings,
             IExceptionReporter exceptionReporter,
@@ -52,7 +54,7 @@ namespace BugSplatUnity.Runtime.Reporter
             var unityCrashesFolder = DirectoryInfoFactory.CreateDirectoryInfo(CrashReporting.crashReportFolder);
             if (!unityCrashesFolder.Exists)
             {
-                Debug.Log($"BugSplat info: unity crash folder {unityCrashesFolder.Name} was not found");
+                Debug.Log(string.Format(noCrashFolderFoundString, CrashReporting.crashReportFolder));
                 yield break;
             }
 
@@ -128,7 +130,7 @@ namespace BugSplatUnity.Runtime.Reporter
             var unityCrashesFolder = DirectoryInfoFactory.CreateDirectoryInfo(CrashReporting.crashReportFolder);
             if (!unityCrashesFolder.Exists)
             {
-                Debug.Log($"BugSplat info: unity crash folder {unityCrashesFolder.Name} was not found");
+                Debug.Log(string.Format(noCrashFolderFoundString, CrashReporting.crashReportFolder));
                 yield break;
             }
 

--- a/Tests/Runtime/Reporter/WindowsReporterTests.cs
+++ b/Tests/Runtime/Reporter/WindowsReporterTests.cs
@@ -13,6 +13,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.Windows;
 
 namespace BugSplatUnity.RuntimeTests.Reporter
 {
@@ -64,7 +65,6 @@ namespace BugSplatUnity.RuntimeTests.Reporter
         public IEnumerator PostAllCrashes_WhenCrashFolderExistsFalse_ShouldNotCallPost()
         {
             var clientSettings = new WebGLClientSettingsRepository();
-            var fakeExceptionClient = new FakeDotNetExceptionClient(new HttpResponseMessage());
             var fakeNativeCrashReportClient = new FakeNativeCrashReportClient(new HttpResponseMessage());
             var fakeDotNetStandardExceptionReporter = new FakeDotNetStandardExceptionReporter(new HttpResponseMessage());
             var sut = new WindowsReporter(clientSettings, fakeDotNetStandardExceptionReporter, fakeNativeCrashReportClient);
@@ -521,6 +521,22 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             yield return completed.AsCoroutine();
 
             Assert.AreEqual(fakeNativeCrashReportPostResponse, result);
+        }
+
+
+        [UnityTest]
+        public IEnumerator PostMostRecentCrash_WhenCrashFolderExistsFalse_ShouldNotCallPost()
+        {
+            var clientSettings = new WebGLClientSettingsRepository();
+            var fakeNativeCrashReportClient = new FakeNativeCrashReportClient(new HttpResponseMessage());
+            var fakeDotNetStandardExceptionReporter = new FakeDotNetStandardExceptionReporter(new HttpResponseMessage());
+            var sut = new WindowsReporter(clientSettings, fakeDotNetStandardExceptionReporter, fakeNativeCrashReportClient);
+            var fakeDirectoryInfo = new FakeDirectoryInfo() { Exists = false };
+            sut.DirectoryInfoFactory = new FakeDirectoryInfoFactory(fakeDirectoryInfo);
+
+            yield return sut.PostMostRecentCrash();
+
+            Assert.IsEmpty(fakeNativeCrashReportClient.Calls);   
         }
 
         [UnityTest]


### PR DESCRIPTION
Gals and Guys, Socialites and Common-folk, you'll be amazed at this PR coming to a town near you!

This PR:
- Fixes #57 
- Adds an exists check to the crash folder in postmostrecentcrash

To note:
- something similar was already being done in postallcrashes, I just ported it over + wrote a test + made sure everything worked in build. 
- Switched folder.name to just use the crashReportFolderPath, as name just printed nothing as the folder was null

And all for only a quarter!