### PR TITLE
Add Option for user to avoid posting exceptions while in editor

### DIFF
--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -76,6 +76,22 @@ namespace BugSplatUnity
         }
 
         /// <summary>
+        /// Determines whether BugSplat should post exceptions when user is in the Unity editor.
+        /// </summary>
+        /// 
+        public bool PostExceptionsInEditor
+        {
+            get
+            {
+                return clientSettings.PostExceptionsInEditor;
+            }
+            set
+            {
+                clientSettings.PostExceptionsInEditor = value;
+            }
+        }
+
+        /// <summary>
         /// A guard that prevents Exceptions from being posted in rapid succession and must be able to handle null - defaults to 1 crash every 10 seconds.
         /// </summary>
         /// 
@@ -225,6 +241,7 @@ namespace BugSplatUnity
             bugSplat.CaptureEditorLog = options.CaptureEditorLog;
             bugSplat.CapturePlayerLog = options.CapturePlayerLog;
             bugSplat.CaptureScreenshots = options.CaptureScreenshots;
+            bugSplat.PostExceptionsInEditor = options.PostExceptionsInEditor;
 
             if (options.PersistentDataFileAttachmentPaths != null)
 			{

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -40,7 +40,7 @@ namespace BugSplatUnity.Runtime.Client
 		public bool CaptureScreenshots;
 
 		[Tooltip("Should BugSplat upload exceptions when in editor")]
-		public bool PostExceptionsInEditor;
+		public bool PostExceptionsInEditor = true;
 
 		[Tooltip("Paths to files (relative to Application.persistentDataPath) to upload with each report")]
 		public List<string> PersistentDataFileAttachmentPaths;

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -39,6 +39,9 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Take a screenshot and upload it when Post is called")]
 		public bool CaptureScreenshots;
 
+		[Tooltip("Should BugSplat upload exceptions when in editor")]
+		public bool PostExceptionsInEditor;
+
 		[Tooltip("Paths to files (relative to Application.persistentDataPath) to upload with each report")]
 		public List<string> PersistentDataFileAttachmentPaths;
 	}

--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -19,7 +19,7 @@ namespace BugSplatUnity.Runtime.Reporter
         private readonly IClientSettingsRepository _clientSettings;
         private readonly IExceptionClient<Task<HttpResponseMessage>> _exceptionClient;
 
-        internal IReportUploadGuardService _reportUploadGuardService = new ReportUploadGuardService(); 
+        internal IReportUploadGuardService _reportUploadGuardService;
 
         public DotNetStandardExceptionReporter(
             IClientSettingsRepository clientSettings,
@@ -28,11 +28,12 @@ namespace BugSplatUnity.Runtime.Reporter
         {
             _clientSettings = clientSettings;
             _exceptionClient = exceptionClient;
+            _reportUploadGuardService = new ReportUploadGuardService(clientSettings);
         }
 
         public void LogMessageReceived(string logMessage, string stackTrace, LogType type, Action callback = null)
         {
-            if (!_reportUploadGuardService.ShouldPostLogMessage(_clientSettings, null, type))
+            if (!_reportUploadGuardService.ShouldPostLogMessage(type))
             {
                 return;
             }
@@ -66,7 +67,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(Exception exception, IReportPostOptions options = null, Action callback = null)
         {
-            if (!_reportUploadGuardService.ShouldPostException(_clientSettings, exception))
+            if (!_reportUploadGuardService.ShouldPostException(exception))
             {
                 yield break;
             }

--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -19,6 +19,8 @@ namespace BugSplatUnity.Runtime.Reporter
         private readonly IClientSettingsRepository _clientSettings;
         private readonly IExceptionClient<Task<HttpResponseMessage>> _exceptionClient;
 
+        internal IReportUploadGuardService _reportUploadGuardService = new ReportUploadGuardService(); 
+
         public DotNetStandardExceptionReporter(
             IClientSettingsRepository clientSettings,
             IExceptionClient<Task<HttpResponseMessage>> exceptionClient
@@ -30,12 +32,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public void LogMessageReceived(string logMessage, string stackTrace, LogType type, Action callback = null)
         {
-            if (type != LogType.Exception)
-            {
-                return;
-            }
-
-            if (!_clientSettings.ShouldPostException(null))
+            if (!_reportUploadGuardService.ShouldPostLogMessage(_clientSettings, null, type))
             {
                 return;
             }
@@ -69,7 +66,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(Exception exception, IReportPostOptions options = null, Action callback = null)
         {
-            if (!_clientSettings.ShouldPostException(exception))
+            if (!_reportUploadGuardService.ShouldPostException(_clientSettings, exception))
             {
                 yield break;
             }

--- a/Runtime/Reporter/ReportUploadGuardService.cs
+++ b/Runtime/Reporter/ReportUploadGuardService.cs
@@ -1,0 +1,37 @@
+using BugSplatUnity.Runtime.Settings;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace BugSplatUnity.Runtime.Reporter
+{
+    internal interface IReportUploadGuardService
+    {
+        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type);
+        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception);
+    }
+
+    internal class ReportUploadGuardService : IReportUploadGuardService
+    {
+        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        {
+            var shouldPostException = clientSettingsRepository.ShouldPostException(exception);
+
+            if (Application.isEditor)
+            {
+                shouldPostException &= clientSettingsRepository.PostExceptionsInEditor;
+            }
+
+            return shouldPostException;
+        }
+
+        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        {
+            var shouldPostLogMessage = ShouldPostException(clientSettingsRepository, exception);
+            shouldPostLogMessage &= (type == LogType.Exception);
+            return shouldPostLogMessage;
+        }
+    }
+}

--- a/Runtime/Reporter/ReportUploadGuardService.cs
+++ b/Runtime/Reporter/ReportUploadGuardService.cs
@@ -9,27 +9,33 @@ namespace BugSplatUnity.Runtime.Reporter
 {
     internal interface IReportUploadGuardService
     {
-        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type);
-        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception);
+        public bool ShouldPostLogMessage(LogType type);
+        public bool ShouldPostException(Exception exception);
     }
 
     internal class ReportUploadGuardService : IReportUploadGuardService
     {
-        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        private IClientSettingsRepository _clientSettingsRepository;
+        public ReportUploadGuardService(IClientSettingsRepository clientSettingsRepository)
         {
-            var shouldPostException = clientSettingsRepository.ShouldPostException(exception);
+            _clientSettingsRepository = clientSettingsRepository;
+        }
+
+        public bool ShouldPostException(Exception exception)
+        {
+            var shouldPostException = _clientSettingsRepository.ShouldPostException(exception);
 
             if (Application.isEditor)
             {
-                shouldPostException &= clientSettingsRepository.PostExceptionsInEditor;
+                shouldPostException &= _clientSettingsRepository.PostExceptionsInEditor;
             }
 
             return shouldPostException;
         }
 
-        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        public bool ShouldPostLogMessage(LogType type)
         {
-            var shouldPostLogMessage = ShouldPostException(clientSettingsRepository, exception);
+            var shouldPostLogMessage = ShouldPostException(null);
             shouldPostLogMessage &= (type == LogType.Exception);
             return shouldPostLogMessage;
         }

--- a/Runtime/Reporter/ReportUploadGuardService.cs.meta
+++ b/Runtime/Reporter/ReportUploadGuardService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac129855ccbe9c9419321c95fa218ec7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Reporter/WebGLReporter.cs
+++ b/Runtime/Reporter/WebGLReporter.cs
@@ -12,7 +12,7 @@ namespace BugSplatUnity.Runtime.Reporter
         public IClientSettingsRepository ClientSettings { get; set; }
         public IExceptionClient<IEnumerator> ExceptionClient { get; set; }
 
-        internal IReportUploadGuardService _reportUploadGuardService = new ReportUploadGuardService();
+        internal IReportUploadGuardService _reportUploadGuardService;
 
         public static WebGLReporter Create(
             IClientSettingsRepository clientSettings,
@@ -23,12 +23,13 @@ namespace BugSplatUnity.Runtime.Reporter
             var reporter = gameObject.AddComponent(typeof(WebGLReporter)) as WebGLReporter;
             reporter.ClientSettings = clientSettings;
             reporter.ExceptionClient = exceptionClient;
+            reporter._reportUploadGuardService = new ReportUploadGuardService(clientSettings);
             return reporter;
         }
 
         public void LogMessageReceived(string logMessage, string stackTrace, LogType type, Action callback = null)
         {
-            if (!_reportUploadGuardService.ShouldPostLogMessage(ClientSettings, null, type))
+            if (!_reportUploadGuardService.ShouldPostLogMessage(type))
             {
                 return;
             }
@@ -46,7 +47,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(Exception ex, IReportPostOptions options = null, Action callback = null)
         {
-            if (!_reportUploadGuardService.ShouldPostException(ClientSettings, ex))
+            if (!_reportUploadGuardService.ShouldPostException(ex))
             {
                 yield break;
             }

--- a/Runtime/Reporter/WebGLReporter.cs
+++ b/Runtime/Reporter/WebGLReporter.cs
@@ -12,6 +12,8 @@ namespace BugSplatUnity.Runtime.Reporter
         public IClientSettingsRepository ClientSettings { get; set; }
         public IExceptionClient<IEnumerator> ExceptionClient { get; set; }
 
+        internal IReportUploadGuardService _reportUploadGuardService = new ReportUploadGuardService();
+
         public static WebGLReporter Create(
             IClientSettingsRepository clientSettings,
             IExceptionClient<IEnumerator> exceptionClient,
@@ -26,12 +28,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public void LogMessageReceived(string logMessage, string stackTrace, LogType type, Action callback = null)
         {
-            if (type != LogType.Exception)
-            {
-                return;
-            }
-
-            if (!ClientSettings.ShouldPostException(null))
+            if (!_reportUploadGuardService.ShouldPostLogMessage(ClientSettings, null, type))
             {
                 return;
             }
@@ -49,7 +46,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(Exception ex, IReportPostOptions options = null, Action callback = null)
         {
-            if (!ClientSettings.ShouldPostException(ex))
+            if (!_reportUploadGuardService.ShouldPostException(ClientSettings, ex))
             {
                 yield break;
             }

--- a/Runtime/Settings/DotNetStandardClientSettingsRepository.cs
+++ b/Runtime/Settings/DotNetStandardClientSettingsRepository.cs
@@ -22,6 +22,8 @@ namespace BugSplatUnity.Runtime.Settings
 
         public bool CaptureScreenshots { get; set; } = false;
 
+        public bool PostExceptionsInEditor { get; set; } = true;
+
         public Func<Exception, bool> ShouldPostException { get; set; } = ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl;
 
         public string Description

--- a/Runtime/Settings/IClientSettingsRepository.cs
+++ b/Runtime/Settings/IClientSettingsRepository.cs
@@ -10,6 +10,7 @@ namespace BugSplatUnity.Runtime.Settings
         bool CaptureEditorLog { get; set; }
         bool CapturePlayerLog { get; set; }
         bool CaptureScreenshots { get; set; }
+        bool PostExceptionsInEditor { get; set; }
         Func<Exception, bool> ShouldPostException { get; set; }
         string Description { get; set; }
         string Email { get; set; }

--- a/Runtime/Settings/WebGLClientSettingsRepository.cs
+++ b/Runtime/Settings/WebGLClientSettingsRepository.cs
@@ -13,6 +13,7 @@ namespace BugSplatUnity.Runtime.Settings
         public bool CaptureEditorLog { get; set; } = false;
         public bool CapturePlayerLog { get; set; } = false;
         public bool CaptureScreenshots { get; set; } = false;
+        public bool PostExceptionsInEditor { get; set; } = true;
         public Func<Exception, bool> ShouldPostException { get; set; } = ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl;
         public string Description { get; set; }
         public string Email { get; set; }

--- a/Samples~/my-unity-crasher/BugSplatOptions.asset
+++ b/Samples~/my-unity-crasher/BugSplatOptions.asset
@@ -22,4 +22,5 @@ MonoBehaviour:
   CaptureEditorLog: 1
   CapturePlayerLog: 1
   CaptureScreenshots: 1
+  PostExceptionsInEditor: 1
   PersistentDataFileAttachmentPaths: []

--- a/Tests/BugSplat.Unity.RuntimeTests.asmdef
+++ b/Tests/BugSplat.Unity.RuntimeTests.asmdef
@@ -13,7 +13,7 @@
     "precompiledReferences": [
         "nunit.framework.dll"
     ],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],

--- a/Tests/BugSplat.Unity.RuntimeTests.asmdef
+++ b/Tests/BugSplat.Unity.RuntimeTests.asmdef
@@ -13,7 +13,7 @@
     "precompiledReferences": [
         "nunit.framework.dll"
     ],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],

--- a/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs
+++ b/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs
@@ -9,12 +9,12 @@ namespace BugSplatUnity.RuntimeTests.Reporter.Fakes
 {
     internal class FakeTrueReportUploadGuardService : IReportUploadGuardService
     {
-        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        public bool ShouldPostException(Exception exception)
         {
             return true;
         }
 
-        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        public bool ShouldPostLogMessage(LogType type)
         {
             return true;
         }
@@ -22,12 +22,12 @@ namespace BugSplatUnity.RuntimeTests.Reporter.Fakes
 
     internal class FakeFalseReportUploadGuardService : IReportUploadGuardService
     {
-        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        public bool ShouldPostException(Exception exception)
         {
             return false;
         }
 
-        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        public bool ShouldPostLogMessage(LogType type)
         {
             return false;
         }

--- a/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs
+++ b/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs
@@ -1,0 +1,35 @@
+using BugSplatUnity.Runtime.Reporter;
+using BugSplatUnity.Runtime.Settings;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BugSplatUnity.RuntimeTests.Reporter.Fakes
+{
+    internal class FakeTrueReportUploadGuardService : IReportUploadGuardService
+    {
+        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        {
+            return true;
+        }
+
+        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        {
+            return true;
+        }
+    }
+
+    internal class FakeFalseReportUploadGuardService : IReportUploadGuardService
+    {
+        public bool ShouldPostException(IClientSettingsRepository clientSettingsRepository, Exception exception)
+        {
+            return false;
+        }
+
+        public bool ShouldPostLogMessage(IClientSettingsRepository clientSettingsRepository, Exception exception, LogType type)
+        {
+            return false;
+        }
+    }
+}

--- a/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs.meta
+++ b/Tests/Runtime/Reporter/Fakes/FakeReportUploadGuardService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c2c650aafeb8c746a99476c906cdf7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
+++ b/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
@@ -1,0 +1,82 @@
+using BugSplatUnity.Runtime.Reporter;
+using BugSplatUnity.Runtime.Settings;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+
+namespace BugSplatUnity.RuntimeTests.Reporter
+{
+    public class ReportUploadGuardServiceTests
+    {
+        [Test]
+        public void ShouldPostException_WhenPostExceptionsInEditorFalse_WhenInEditor_ShouldReturnFalse()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.PostExceptionsInEditor = false;
+            clientSettings.ShouldPostException = (Exception ex) => true;
+            var exception = new Exception();
+
+            Assert.IsFalse(rugs.ShouldPostException(clientSettings, exception));
+        }
+
+        [Test]
+        public void ShouldPostException_WhenPostExceptionsInEditorTrue_WhenInEditor_ShouldReturnTrue()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.PostExceptionsInEditor = true;
+            clientSettings.ShouldPostException = (Exception ex) => true;
+            var exception = new Exception();
+
+            Assert.IsTrue(rugs.ShouldPostException(clientSettings, exception));
+        }
+
+        [Test]
+        public void ShouldPostException_WhenClientSettingsRepositoryShouldPostExceptionFalse_ShouldReturnFalse()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.ShouldPostException = (Exception ex) => false;
+            var exception = new Exception();
+
+            Assert.IsFalse(rugs.ShouldPostException(clientSettings, exception));
+        }
+
+        [Test]
+        public void ShouldPostException_WhenClientSettingsRepositoryShouldPostExceptionTrue_ShouldReturnTrue()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.ShouldPostException = (Exception ex) => true;
+            var exception = new Exception();
+
+            Assert.IsTrue(rugs.ShouldPostException(clientSettings, exception));
+        }
+
+        [Test]
+        public void ShouldPostLogMessage_WhenLogTypeNotException_ShouldReturnFalse()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            var exception = new Exception();
+            clientSettings.ShouldPostException = (Exception ex) => true;
+            var logType = LogType.Error;
+
+            Assert.IsFalse(rugs.ShouldPostLogMessage(clientSettings, exception, logType));
+        }
+
+        [Test]
+        public void ShouldPostLogMessage_WhenLogTypeException_ShouldReturnTrue()
+        {
+            var rugs = new ReportUploadGuardService();
+            var clientSettings = new WebGLClientSettingsRepository();
+            var exception = new Exception();
+            clientSettings.ShouldPostException = (Exception ex) => true;
+            var logType = LogType.Exception;
+
+            Assert.IsTrue(rugs.ShouldPostLogMessage(clientSettings, exception, logType));
+        }
+    }
+}
+

--- a/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
+++ b/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
@@ -11,71 +11,71 @@ namespace BugSplatUnity.RuntimeTests.Reporter
         [Test]
         public void ShouldPostException_WhenPostExceptionsInEditorFalse_WhenInEditor_ShouldReturnFalse()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
             clientSettings.PostExceptionsInEditor = false;
             clientSettings.ShouldPostException = (Exception ex) => true;
+            var rugs = new ReportUploadGuardService(clientSettings);
             var exception = new Exception();
 
-            Assert.IsFalse(rugs.ShouldPostException(clientSettings, exception));
+            Assert.IsFalse(rugs.ShouldPostException(exception));
         }
 
         [Test]
         public void ShouldPostException_WhenPostExceptionsInEditorTrue_WhenInEditor_ShouldReturnTrue()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
             clientSettings.PostExceptionsInEditor = true;
             clientSettings.ShouldPostException = (Exception ex) => true;
+            var rugs = new ReportUploadGuardService(clientSettings);
             var exception = new Exception();
 
-            Assert.IsTrue(rugs.ShouldPostException(clientSettings, exception));
+            Assert.IsTrue(rugs.ShouldPostException(exception));
         }
 
         [Test]
         public void ShouldPostException_WhenClientSettingsRepositoryShouldPostExceptionFalse_ShouldReturnFalse()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
             clientSettings.ShouldPostException = (Exception ex) => false;
+            var rugs = new ReportUploadGuardService(clientSettings);
             var exception = new Exception();
 
-            Assert.IsFalse(rugs.ShouldPostException(clientSettings, exception));
+            Assert.IsFalse(rugs.ShouldPostException(exception));
         }
 
         [Test]
         public void ShouldPostException_WhenClientSettingsRepositoryShouldPostExceptionTrue_ShouldReturnTrue()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
             clientSettings.ShouldPostException = (Exception ex) => true;
+            var rugs = new ReportUploadGuardService(clientSettings);
             var exception = new Exception();
 
-            Assert.IsTrue(rugs.ShouldPostException(clientSettings, exception));
+            Assert.IsTrue(rugs.ShouldPostException(exception));
         }
 
         [Test]
         public void ShouldPostLogMessage_WhenLogTypeNotException_ShouldReturnFalse()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
-            var exception = new Exception();
             clientSettings.ShouldPostException = (Exception ex) => true;
+            var rugs = new ReportUploadGuardService(clientSettings);
+            var exception = new Exception();
             var logType = LogType.Error;
 
-            Assert.IsFalse(rugs.ShouldPostLogMessage(clientSettings, exception, logType));
+            Assert.IsFalse(rugs.ShouldPostLogMessage(logType));
         }
 
         [Test]
         public void ShouldPostLogMessage_WhenLogTypeException_ShouldReturnTrue()
         {
-            var rugs = new ReportUploadGuardService();
             var clientSettings = new WebGLClientSettingsRepository();
-            var exception = new Exception();
             clientSettings.ShouldPostException = (Exception ex) => true;
+            var rugs = new ReportUploadGuardService(clientSettings);         
+            var exception = new Exception();
             var logType = LogType.Exception;
 
-            Assert.IsTrue(rugs.ShouldPostLogMessage(clientSettings, exception, logType));
+            Assert.IsTrue(rugs.ShouldPostLogMessage(logType));
         }
     }
 }

--- a/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs.meta
+++ b/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4fbc485478a1c046bcf6519235823c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Ladies and Gents, let's get rrrready to rrrumble. Tuesday, tuesday, tuesday only we have a monster pull request, he's rough, he's tough, and he does the following:
- [x] Closes  #43 
- [x] Adds ReportUploadGuardService, a reusable means of checking whether a report should get uploaded. This can be used for the future IOS and Android reporter.
- [x] Updates test suite, moving repeated tests to new ReportUploadGuardService tests instead.
- [x] Pumps it up to 11, replaces diesel with 100% Pure Rage Energy Drink

Before merging, the following needs to be addressed:
- [x] Update README to account for new option

Remember folks, first 50 reviewers get a free scrap of metal, only at the GitMerge Coliseum.