### PR TITLE
If an exception/log message is denied, it shouldn't call ClientSettingsRepository ShouldPostException

### DIFF
--- a/Runtime/Reporter/ReportUploadGuardService.cs
+++ b/Runtime/Reporter/ReportUploadGuardService.cs
@@ -23,21 +23,22 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public bool ShouldPostException(Exception exception)
         {
-            var shouldPostException = _clientSettingsRepository.ShouldPostException(exception);
-
-            if (Application.isEditor)
+            if (Application.isEditor && !_clientSettingsRepository.PostExceptionsInEditor)
             {
-                shouldPostException &= _clientSettingsRepository.PostExceptionsInEditor;
+                return false;
             }
 
-            return shouldPostException;
+            return _clientSettingsRepository.ShouldPostException(exception);
         }
 
         public bool ShouldPostLogMessage(LogType type)
         {
-            var shouldPostLogMessage = ShouldPostException(null);
-            shouldPostLogMessage &= (type == LogType.Exception);
-            return shouldPostLogMessage;
+            if (type != LogType.Exception)
+            {
+                return false;
+            }
+
+            return ShouldPostException(null);
         }
     }
 }

--- a/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
+++ b/Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs
@@ -55,6 +55,26 @@ namespace BugSplatUnity.RuntimeTests.Reporter
         }
 
         [Test]
+        public void ShouldPostException_WhenPostExceptionsInEditorFalse_WhenInEditor_ShouldNotCallClientSettingsRepositoryShouldPostException()
+        {
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.PostExceptionsInEditor = false;
+
+            var called = false;
+            clientSettings.ShouldPostException = (Exception ex) =>
+            {
+                called = true;
+                return false;
+            };
+
+            var rugs = new ReportUploadGuardService(clientSettings);
+            var exception = new Exception();
+
+            rugs.ShouldPostException(exception);
+            Assert.IsFalse(called);
+        }
+
+        [Test]
         public void ShouldPostLogMessage_WhenLogTypeNotException_ShouldReturnFalse()
         {
             var clientSettings = new WebGLClientSettingsRepository();
@@ -76,6 +96,46 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             var logType = LogType.Exception;
 
             Assert.IsTrue(rugs.ShouldPostLogMessage(logType));
+        }
+
+        [Test]
+        public void ShouldPostLogMessage_WhenLogTypeNotException_ShouldNotCallClientSettingsRepositoryShouldPostException()
+        {
+            var clientSettings = new WebGLClientSettingsRepository();
+            var rugs = new ReportUploadGuardService(clientSettings);
+            var exception = new Exception();
+            var logType = LogType.Error;
+
+
+            var called = false;
+            clientSettings.ShouldPostException = (Exception ex) =>
+            {
+                called = true;
+                return false;
+            };
+
+            rugs.ShouldPostLogMessage(logType);
+            Assert.IsFalse(called);
+        }
+
+        [Test]
+        public void ShouldPostLogMessage_WhenPostExceptionsInEditorTrue_WhenLogTypeException_ShouldCallClientSettingsRepositoryShouldPostException()
+        {
+            var clientSettings = new WebGLClientSettingsRepository();
+            clientSettings.PostExceptionsInEditor = true;
+
+            var called = false;
+            clientSettings.ShouldPostException = (Exception ex) =>
+            {
+                called = true;
+                return false;
+            };
+
+            var rugs = new ReportUploadGuardService(clientSettings);
+            var logType = LogType.Exception;
+
+            rugs.ShouldPostLogMessage(logType);
+            Assert.IsTrue(called);
         }
     }
 }


### PR DESCRIPTION
You lot arn't headin' up to Bug Fix Mountain are you? Praytell, 'ave you 'eard of the beast that roams those hills? Have you 'eard the tales of what it's done:
- [x] Closes #63 
- [x] Ensures that ClientSettingsRepository ShouldPostException isn't called when the exception/log message is denied already.

Mhm. Nothin' but trouble up dem mountains. Best be careful, now.