### PR TITLE
feat: add support for Unity 2019

### DIFF
--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -78,7 +78,6 @@ namespace BugSplatUnity
         /// <summary>
         /// Determines whether BugSplat should post exceptions when user is in the Unity editor.
         /// </summary>
-        /// 
         public bool PostExceptionsInEditor
         {
             get
@@ -94,8 +93,6 @@ namespace BugSplatUnity
         /// <summary>
         /// A guard that prevents Exceptions from being posted in rapid succession and must be able to handle null - defaults to 1 crash every 10 seconds.
         /// </summary>
-        /// 
-        // TODO can we be more explicit that the Exception might be null with the Type here?
         public Func<Exception, bool> ShouldPostException
         {
             get

--- a/Runtime/Client/UnityWebClient.cs
+++ b/Runtime/Client/UnityWebClient.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine.Networking;
+#if UNITY_2020_1_OR_NEWER
 using static UnityEngine.Networking.UnityWebRequest;
+#endif
 
 namespace BugSplatUnity.Runtime.Client
 {
@@ -13,8 +14,8 @@ namespace BugSplatUnity.Runtime.Client
     internal interface IUnityWebRequest
     {
         UnityWebRequestAsyncOperation SendWebRequest();
-        Result result { get; }
-        string error { get; }
+        bool Success { get; }
+        string Error { get; }
         long responseCode { get; }
         IDownloadHandler downloadHandler { get; }
     }
@@ -35,8 +36,12 @@ namespace BugSplatUnity.Runtime.Client
 
     internal class WrappedUnityWebRequest: IUnityWebRequest
     {
-        public Result result => _request.result;
-        public string error => _request.error;
+#if UNITY_2020_1_OR_NEWER
+        public bool Success => _request.result == UnityWebRequest.Result.Success;
+#else
+        public bool Success => !_request.isHttpError && !_request.isNetworkError;
+#endif
+        public string Error => _request.error;
         public long responseCode => _request.responseCode;
         public IDownloadHandler downloadHandler => new WrappedDownloadHandler(_request.downloadHandler);
 

--- a/Runtime/Client/UnityWebClient.cs
+++ b/Runtime/Client/UnityWebClient.cs
@@ -8,7 +8,7 @@ namespace BugSplatUnity.Runtime.Client
 {
     internal interface IDownloadHandler
     {
-        string text { get; }
+        string Text { get; }
     }
 
     internal interface IUnityWebRequest
@@ -16,8 +16,8 @@ namespace BugSplatUnity.Runtime.Client
         UnityWebRequestAsyncOperation SendWebRequest();
         bool Success { get; }
         string Error { get; }
-        long responseCode { get; }
-        IDownloadHandler downloadHandler { get; }
+        long ResponseCode { get; }
+        IDownloadHandler DownloadHandler { get; }
     }
 
     internal interface IUnityWebClient
@@ -42,8 +42,8 @@ namespace BugSplatUnity.Runtime.Client
         public bool Success => !_request.isHttpError && !_request.isNetworkError;
 #endif
         public string Error => _request.error;
-        public long responseCode => _request.responseCode;
-        public IDownloadHandler downloadHandler => new WrappedDownloadHandler(_request.downloadHandler);
+        public long ResponseCode => _request.responseCode;
+        public IDownloadHandler DownloadHandler => new WrappedDownloadHandler(_request.downloadHandler);
 
         private readonly UnityWebRequest _request;
 
@@ -60,7 +60,7 @@ namespace BugSplatUnity.Runtime.Client
 
     internal class WrappedDownloadHandler : IDownloadHandler
     {
-        public string text => _downloadHandler.text;
+        public string Text => _downloadHandler.text;
 
         private readonly DownloadHandler _downloadHandler;
 

--- a/Runtime/Client/WebGLExceptionClient.cs
+++ b/Runtime/Client/WebGLExceptionClient.cs
@@ -1,5 +1,4 @@
-﻿using BugSplatDotNetStandard;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -34,7 +33,7 @@ namespace BugSplatUnity.Runtime.Client
 
         private IEnumerator PostException(string exception, IReportPostOptions options = null)
         {
-            options ??= new ReportPostOptions();
+            options = options ?? new ReportPostOptions();
 
             var url = $"https://{_database}.bugsplat.com/post/dotnetstandard/";
             var formData = new Dictionary<string, string>()
@@ -53,9 +52,9 @@ namespace BugSplatUnity.Runtime.Client
             var request = UnityWebClient.Post(url, formData);
             yield return request.SendWebRequest();
 
-            if (request.result != UnityWebRequest.Result.Success)
+            if (!request.Success)
             {
-                Debug.LogError($"BugSplat error: Could not post exception {request.error}");
+                Debug.LogError($"BugSplat error: Could not post exception {request.Error}");
                 yield break;
             }
 

--- a/Runtime/Client/WebGLExceptionClient.cs
+++ b/Runtime/Client/WebGLExceptionClient.cs
@@ -58,7 +58,7 @@ namespace BugSplatUnity.Runtime.Client
                 yield break;
             }
 
-            Debug.Log($"BugSplat info: status {request.responseCode}\n {request.downloadHandler.text}");
+            Debug.Log($"BugSplat info: status {request.ResponseCode}\n {request.DownloadHandler.Text}");
         }
     }
 }

--- a/Runtime/ReportPostOptions.cs
+++ b/Runtime/ReportPostOptions.cs
@@ -7,13 +7,13 @@ namespace BugSplatUnity
 {
     public interface IReportPostOptions
     {
-        public List<FileInfo> AdditionalAttachments { get; }
-        public List<FormDataParam> AdditionalFormDataParams { get; }
-        public string Description { get; set; }
-        public string Email { get; set; }
-        public string Key { get; set; }
-        public string User { get; set; }
-        public int CrashTypeId { get; set; }
+        List<FileInfo> AdditionalAttachments { get; }
+        List<FormDataParam> AdditionalFormDataParams { get; }
+        string Description { get; set; }
+        string Email { get; set; }
+        string Key { get; set; }
+        string User { get; set; }
+        int CrashTypeId { get; set; }
     }
 
     public class FormDataParam : IFormDataParam

--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -72,7 +72,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 yield break;
             }
 
-            options ??= new ReportPostOptions();
+            options = options ?? new ReportPostOptions();
             options.SetNullOrEmptyValues(_clientSettings);
             options.CrashTypeId = (int)BugSplatDotNetStandard.BugSplat.ExceptionTypeId.Unity;
 

--- a/Runtime/Reporter/ReportUploadGuardService.cs
+++ b/Runtime/Reporter/ReportUploadGuardService.cs
@@ -9,8 +9,8 @@ namespace BugSplatUnity.Runtime.Reporter
 {
     internal interface IReportUploadGuardService
     {
-        public bool ShouldPostLogMessage(LogType type);
-        public bool ShouldPostException(Exception exception);
+        bool ShouldPostLogMessage(LogType type);
+        bool ShouldPostException(Exception exception);
     }
 
     internal class ReportUploadGuardService : IReportUploadGuardService

--- a/Runtime/Reporter/WebGLReporter.cs
+++ b/Runtime/Reporter/WebGLReporter.cs
@@ -52,7 +52,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 yield break;
             }
 
-            options ??= new ReportPostOptions();
+            options = options ?? new ReportPostOptions();
             options.SetNullOrEmptyValues(ClientSettings);
             options.CrashTypeId = (int)BugSplatDotNetStandard.BugSplat.ExceptionTypeId.Unity;
 

--- a/Runtime/Reporter/WindowsReporter.cs
+++ b/Runtime/Reporter/WindowsReporter.cs
@@ -79,7 +79,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator PostCrash(IDirectoryInfo crashFolder, IReportPostOptions options = null, Action<HttpResponseMessage> callback = null)
         {
-            options ??= new ReportPostOptions();
+            options = options ?? new ReportPostOptions();
 
             if (!crashFolder.Exists)
             {
@@ -143,7 +143,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(FileInfo minidump, IReportPostOptions options = null, Action<HttpResponseMessage> callback = null)
         {
-            options ??= new ReportPostOptions();
+            options = options ?? new ReportPostOptions();
             options.SetNullOrEmptyValues(_clientSettings);
 
             yield return Task.Run(

--- a/Runtime/Util/WrappedDirectoryInfo.cs
+++ b/Runtime/Util/WrappedDirectoryInfo.cs
@@ -6,17 +6,17 @@ namespace BugSplatUnity.Runtime.Util
 {
     internal interface IDirectoryInfoFactory
     {
-        public IDirectoryInfo CreateDirectoryInfo(string path);
+        IDirectoryInfo CreateDirectoryInfo(string path);
     }
 
     internal interface IDirectoryInfo
     {
-        public IDirectoryInfo[] GetDirectories();
-        public FileInfo[] GetFiles();
-        public bool Exists { get; }
-        public string FullName { get; }
-        public DateTime LastWriteTime { get; }
-        public string Name { get; }
+        IDirectoryInfo[] GetDirectories();
+        FileInfo[] GetFiles();
+        bool Exists { get; }
+        string FullName { get; }
+        DateTime LastWriteTime { get; }
+        string Name { get; }
     }
 
     class WrappedDirectoryInfo : IDirectoryInfo

--- a/Samples~/my-unity-crasher/Scripts/BugSplatLayoutButtons.cs
+++ b/Samples~/my-unity-crasher/Scripts/BugSplatLayoutButtons.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -10,7 +8,6 @@ public class BugSplatLayoutButtons : MonoBehaviour
     private readonly Color bugSplatGreen = new Color32(74, 235, 195, 255);
     private readonly Color bugSplatBlue = new Color32(58, 163, 255, 255);
     
-
     void Start()
     {
         var images = transform.GetComponentsInChildren<Image>();

--- a/Samples~/my-unity-crasher/Scripts/Crasher.cs
+++ b/Samples~/my-unity-crasher/Scripts/Crasher.cs
@@ -23,31 +23,6 @@ namespace Crasher
 #endif
         }
 
-        private void generateSampleStackFramesAndThrow()
-		{
-			sampleStackFrame0();
-		}
-
-		private void sampleStackFrame0()
-		{
-			sampleStackFrame1();
-		}
-
-		private void sampleStackFrame1()
-		{
-			sampleStackFrame2();
-		}
-
-		private void sampleStackFrame2()
-		{
-			throwException();
-		}
-
-		private void throwException()
-		{
-			throw new Exception("BugSplat rocks!");
-		}
-
 		public void Event_ForceCrash(ForcedCrashCategory category)
 		{
 			Utils.ForceCrash(category);
@@ -57,7 +32,7 @@ namespace Crasher
 		{
 			try
 			{
-				generateSampleStackFramesAndThrow();
+				GenerateSampleStackFramesAndThrow();
 			}
 			catch (Exception ex)
 			{
@@ -66,18 +41,43 @@ namespace Crasher
 					Description = "a new description"
 				};
 
-				static void callback()
-				{
-					Debug.Log($"Exception post callback!");
-				};
-
-				StartCoroutine(bugsplat.Post(ex, options, callback));
+				StartCoroutine(bugsplat.Post(ex, options, ExceptionCallback));
 			}
 		}
 
 		public void Event_ThrowException()
 		{
-			generateSampleStackFramesAndThrow();
+			GenerateSampleStackFramesAndThrow();
+		}
+
+		private void GenerateSampleStackFramesAndThrow()
+		{
+			SampleStackFrame0();
+		}
+
+		private void SampleStackFrame0()
+		{
+			SampleStackFrame1();
+		}
+
+		private void SampleStackFrame1()
+		{
+			SampleStackFrame2();
+		}
+
+		private void SampleStackFrame2()
+		{
+			ThrowException();
+		}
+
+		private void ThrowException()
+		{
+			throw new Exception("BugSplat rocks!");
+		}
+
+		static void ExceptionCallback()
+		{
+			Debug.Log($"Exception post callback!");
 		}
 	}
 }

--- a/Tests/BugSplat.Unity.RuntimeTests.asmdef
+++ b/Tests/BugSplat.Unity.RuntimeTests.asmdef
@@ -4,9 +4,10 @@
     "references": [
         "BugSplat.Unity.Runtime"
     ],
-    "includePlatforms": [
-        "Editor"
+    "optionalUnityReferences": [
+        "TestAssemblies"
     ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/Tests/Runtime/Client/Fakes/FakeUnityWebClient.cs
+++ b/Tests/Runtime/Client/Fakes/FakeUnityWebClient.cs
@@ -34,10 +34,10 @@ namespace BugSplatUnity.RuntimeTests.Client.Fakes
 
     class FakeUnityWebRequest : IUnityWebRequest
     {
-        public UnityWebRequest.Result result { get; set; } = UnityWebRequest.Result.Success;
-        public string error { get; set; } = string.Empty;
-        public long responseCode { get; set; } = 200;
-        public IDownloadHandler downloadHandler { get; set; } = new FakeDownloadHandler(string.Empty);
+        public bool Success { get; set; } = true;
+        public string Error { get; set; } = string.Empty;
+        public long ResponseCode { get; set; } = 200;
+        public IDownloadHandler DownloadHandler { get; set; } = new FakeDownloadHandler(string.Empty);
 
         public UnityWebRequestAsyncOperation SendWebRequest()
         {
@@ -47,11 +47,11 @@ namespace BugSplatUnity.RuntimeTests.Client.Fakes
 
     class FakeDownloadHandler : IDownloadHandler
     {
-        public string text { get; }
+        public string Text { get; }
 
-        public FakeDownloadHandler(string txt)
+        public FakeDownloadHandler(string text)
         {
-            text = txt;
+            Text = text;
         }
     }
 


### PR DESCRIPTION
### Description

* Added support for Unity 2019 by back-porting some C# 8.0 syntax to C# 7.3 and changed an internal interface. The internal interface was used to determine if a UnityWebRequest was successful or not and relied on a property that wasn't available back in Unity 2019 and was fixed by a `#if UNITY_2020_1_OR_NEWER` build conditional.
* Fixes warnings about Naming Rule Violations.
* Fixes UnitTests that wouldn't run in Unity 2021

Fixes #71 Fixes #70 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
