### PR TITLE
fix(BugSplatManager): unregister logMessageReceived on destruction

### DIFF
--- a/Runtime/Manager/BugSplatManager.cs
+++ b/Runtime/Manager/BugSplatManager.cs
@@ -33,13 +33,23 @@ namespace BugSplatUnity.Runtime.Manager
 
 			if (registerLogMessageReceived)
 			{
-				Application.logMessageReceived += (logMessage, stackTrace, type) => StartCoroutine(bugsplat.LogMessageReceived(logMessage, stackTrace, type));
+				Application.logMessageReceived += LogMessageReceivedHandler;
 			}
-			
+
 			if (dontDestroyManagerOnSceneLoad)
 			{
-                DontDestroyOnLoad(this);
+				DontDestroyOnLoad(this);
 			}
+		}
+
+		private void OnDestroy()
+		{
+			Application.logMessageReceived -= LogMessageReceivedHandler;
+		}
+
+		void LogMessageReceivedHandler(string logMessage, string stackTrace, LogType type)
+		{
+			StartCoroutine(bugsplatRef.BugSplat.LogMessageReceived(logMessage, stackTrace, type));
 		}
 	}
 }


### PR DESCRIPTION
Application.logMessageReceived is a static callback handler, which isn't reset when changing scenes or when exiting play mode if domain reloads are not enabled.

When destroying the class without unregistering, e.g. due to scene change or existing play mode, the callback will then try to start a coroutine on the destroyed object.