### PR TITLE
fix: windows build

### DIFF
--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -275,7 +275,7 @@ public class BuildPostprocessors
 
 		if (string.IsNullOrEmpty(options.SymbolUploadClientSecret))
 		{
-			Debug.LogWarning("BugSplat.SymbolUploadClientSecret is not set in BugSplatOptions. Skipping symbol uploads");
+			Debug.LogWarning("BugSplat.SymbolUploadClientSecret is not set in BugSplatOptions. Skipping symbol uploads...");
 			onCompleted(0);
 			return;
 		}

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -9,13 +9,15 @@ using BugSplatDotNetStandard;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
-using Unity.Android.Types;
 using BugSplatUnity.Runtime.Client;
 using Debug = UnityEngine.Debug;
 using BugSplatDotNetStandard.Api;
 using BugSplatDotNetStandard.Http;
+#if UNITY_ANDROID
+using Unity.Android.Types;
 using Unity.Android.Gradle;
 using UserBuildSettings = UnityEditor.Android.UserBuildSettings;
+#endif
 
 #if UNITY_IOS
 using UnityEditor.iOS.Xcode;
@@ -266,15 +268,15 @@ public class BuildPostprocessors
 	{
 		if (string.IsNullOrEmpty(options.SymbolUploadClientId))
 		{
-			Debug.LogError("BugSplat. SymbolUploadClientId is not set in BugSplatOptions. Will not upload symbols.");
-			onCompleted(-1);
+			Debug.LogWarning("BugSplat.SymbolUploadClientId is not set in BugSplatOptions. Skipping symbol uploads...");
+			onCompleted(0);
 			return;
 		}
 
 		if (string.IsNullOrEmpty(options.SymbolUploadClientSecret))
 		{
-			Debug.LogError("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions. Will not upload symbols.");
-			onCompleted(-1);
+			Debug.LogWarning("BugSplat.SymbolUploadClientSecret is not set in BugSplatOptions. Skipping symbol uploads");
+			onCompleted(0);
 			return;
 		}
 

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -13,11 +13,6 @@ using BugSplatUnity.Runtime.Client;
 using Debug = UnityEngine.Debug;
 using BugSplatDotNetStandard.Api;
 using BugSplatDotNetStandard.Http;
-#if UNITY_ANDROID
-using Unity.Android.Types;
-using Unity.Android.Gradle;
-using UserBuildSettings = UnityEditor.Android.UserBuildSettings;
-#endif
 
 #if UNITY_IOS
 using UnityEditor.iOS.Xcode;
@@ -199,7 +194,7 @@ public class BuildPostprocessors
 			return;
 		}
 
-		if (UserBuildSettings.DebugSymbols.level == DebugSymbolLevel.None)
+		if (UnityEditor.Android.UserBuildSettings.DebugSymbols.level == Unity.Android.Types.DebugSymbolLevel.None)
 		{
 			Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Debug Symbols\" is set to None in BuildSettings->Android.");
 			return;
@@ -268,14 +263,14 @@ public class BuildPostprocessors
 	{
 		if (string.IsNullOrEmpty(options.SymbolUploadClientId))
 		{
-			Debug.LogWarning("BugSplat.SymbolUploadClientId is not set in BugSplatOptions. Skipping symbol uploads...");
+			Debug.LogWarning("BugSplat. SymbolUploadClientId is not set in BugSplatOptions. Skipping symbol uploads...");
 			onCompleted(0);
 			return;
 		}
 
 		if (string.IsNullOrEmpty(options.SymbolUploadClientSecret))
 		{
-			Debug.LogWarning("BugSplat.SymbolUploadClientSecret is not set in BugSplatOptions. Skipping symbol uploads...");
+			Debug.LogWarning("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions. Skipping symbol uploads");
 			onCompleted(0);
 			return;
 		}


### PR DESCRIPTION
### Description

Adds #if for Android only includes. Doesn't stop build if clientId and clientSecret are missing.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
