### PR TITLE
fix: add Dictionary TryAdd extension for Unity 2021

### DIFF
--- a/Runtime/Client/DotNetStandardClient.cs
+++ b/Runtime/Client/DotNetStandardClient.cs
@@ -4,6 +4,10 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
+#if !UNITY_2022_1_OR_NEWER
+using BugSplatUnity.Runtime.Util.Extensions;
+#endif
+
 namespace BugSplatUnity.Runtime.Client
 {
     internal interface IDotNetStandardExceptionClient

--- a/Runtime/Plugins/BugSplatDotNetStandard.dll.meta
+++ b/Runtime/Plugins/BugSplatDotNetStandard.dll.meta
@@ -1,2 +1,33 @@
 fileFormatVersion: 2
 guid: 51532154bbdb24d71babff241f230a10
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Reporter/WebGLReporter.cs
+++ b/Runtime/Reporter/WebGLReporter.cs
@@ -5,6 +5,10 @@ using System;
 using System.Collections;
 using UnityEngine;
 
+#if !UNITY_2022_1_OR_NEWER
+using BugSplatUnity.Runtime.Util.Extensions;
+#endif
+
 namespace BugSplatUnity.Runtime.Reporter
 {
     internal class WebGLReporter : IExceptionReporter

--- a/Runtime/Util/DictionaryExtensions.cs
+++ b/Runtime/Util/DictionaryExtensions.cs
@@ -1,0 +1,17 @@
+#if !UNITY_2022_1_OR_NEWER
+using System.Collections.Generic;
+
+namespace BugSplatUnity.Runtime.Util.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if (dictionary == null) return false;
+            if (dictionary.ContainsKey(key)) return false;
+            dictionary.Add(key, value);
+            return true;
+        }
+    }
+}
+#endif

--- a/Runtime/Util/DictionaryExtensions.cs.meta
+++ b/Runtime/Util/DictionaryExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ad6cf6bb0770004290306427cd3be9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Util/ReportPostOptionsExtensions.cs
+++ b/Runtime/Util/ReportPostOptionsExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using BugSplatUnity.Runtime.Settings;
 using System.Collections.Generic;
 
+#if !UNITY_2022_1_OR_NEWER
+using BugSplatUnity.Runtime.Util.Extensions;
+#endif
+
 namespace BugSplatUnity.Runtime.Util
 {
     internal static class ReportPostOptionsExtensions

--- a/Tests/Runtime/Client/Fakes/FakeUnityWebClient.cs
+++ b/Tests/Runtime/Client/Fakes/FakeUnityWebClient.cs
@@ -65,5 +65,7 @@ namespace BugSplatUnity.RuntimeTests.Client.Fakes
         public string Notes { get; set; }
         public string User { get; set; }
         public int CrashTypeId { get; set; }
+
+        public Dictionary<string, string> AdditionalAttributes => new Dictionary<string,string>();
     }
 }


### PR DESCRIPTION
### Description

This apparently isn't part of the .NET standard 2.0 which is used by Unity 2021.

### TODO BG
- [x] Test in 2022

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
