### PR TITLE
chore: add rate limit tests for ShouldPostExceptionImpl

### DIFF
--- a/Tests/Runtime/Util/ShouldPostExceptionImplTests.cs
+++ b/Tests/Runtime/Util/ShouldPostExceptionImplTests.cs
@@ -1,13 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using BugSplatUnity.Runtime.Util;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+using System.Threading;
 
 namespace BugSplatUnity.RuntimeTests.Util
 {
     class ShouldPostExceptionImplTests
     {
-        // TODO
+        [Test]
+        public void DefaultShouldPostExceptionImpl_ShouldRespectRateLimiting()
+        {
+            // Reset internal lastPost field to ensure test independence
+            var field = typeof(ShouldPostExceptionImpl).GetField("lastPost", BindingFlags.NonPublic | BindingFlags.Static);
+            field.SetValue(null, new DateTime(0));
+
+            // First call should be allowed
+            Assert.IsTrue(ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl());
+
+            // Second immediate call should be blocked
+            Assert.IsFalse(ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl());
+
+            // After waiting for 3 seconds a subsequent call should be allowed
+            Thread.Sleep(TimeSpan.FromSeconds(3));
+            Assert.IsTrue(ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand test coverage
- add rate limit verification tests for `ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl`

## Testing
- `npm test` *(fails: missing script)*
- `dotnet test` *(fails: command not found)*