### PR TITLE
Fix DotNetStandardClient null options

### DIFF
--- a/Runtime/Client/DotNetStandardClient.cs
+++ b/Runtime/Client/DotNetStandardClient.cs
@@ -43,6 +43,7 @@ namespace BugSplatUnity.Runtime.Client
 
         private ExceptionPostOptions CreateExceptionPostOptions(IReportPostOptions options)
         {
+            options ??= new ReportPostOptions();
             var exceptionPostOptions = new ExceptionPostOptions();
             
             foreach (var attribute in options.AdditionalAttributes) 
@@ -63,6 +64,7 @@ namespace BugSplatUnity.Runtime.Client
 
         private MinidumpPostOptions CreateMinidumpPostOptions(IReportPostOptions options)
         {
+            options ??= new ReportPostOptions();
             var minidumpPostOptions = new MinidumpPostOptions();
             
             foreach (var attribute in options.AdditionalAttributes) 

--- a/Tests/Runtime/Client/DotNetStandardClientTests.cs
+++ b/Tests/Runtime/Client/DotNetStandardClientTests.cs
@@ -1,0 +1,50 @@
+using BugSplatDotNetStandard;
+using BugSplatUnity.Runtime.Client;
+using BugSplatUnity.RuntimeTests.Client.Fakes;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace BugSplatUnity.RuntimeTests.Client
+{
+    public class DotNetStandardClientTests
+    {
+        [Test]
+        public void Post_WithStackTraceNullOptions_ShouldCreateOptions()
+        {
+            var bugSplat = new FakeBugSplat("db", "app", "1.0");
+            var sut = new DotNetStandardClient(bugSplat);
+
+            sut.Post("stackTrace");
+
+            Assert.IsNotEmpty(bugSplat.ExceptionCalls);
+            Assert.NotNull(bugSplat.ExceptionCalls[0].Options);
+        }
+
+        [Test]
+        public void Post_WithExceptionNullOptions_ShouldCreateOptions()
+        {
+            var bugSplat = new FakeBugSplat("db", "app", "1.0");
+            var sut = new DotNetStandardClient(bugSplat);
+
+            sut.Post(new Exception("oops"));
+
+            Assert.IsNotEmpty(bugSplat.ExceptionCalls);
+            Assert.NotNull(bugSplat.ExceptionCalls[0].Options);
+        }
+
+        [Test]
+        public void Post_WithMinidumpNullOptions_ShouldCreateOptions()
+        {
+            var bugSplat = new FakeBugSplat("db", "app", "1.0");
+            var sut = new DotNetStandardClient(bugSplat);
+            var file = new FileInfo("test.dmp");
+
+            sut.Post(file);
+
+            Assert.IsNotEmpty(bugSplat.MinidumpCalls);
+            Assert.NotNull(bugSplat.MinidumpCalls[0].Options);
+        }
+    }
+}

--- a/Tests/Runtime/Client/DotNetStandardClientTests.cs.meta
+++ b/Tests/Runtime/Client/DotNetStandardClientTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 768667da11af4117bf017b7e8af08282
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Client/Fakes/FakeBugSplat.cs
+++ b/Tests/Runtime/Client/Fakes/FakeBugSplat.cs
@@ -1,0 +1,51 @@
+using BugSplatDotNetStandard;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace BugSplatUnity.RuntimeTests.Client.Fakes
+{
+    class FakeBugSplat : BugSplat
+    {
+        public List<ExceptionPostCall> ExceptionCalls { get; } = new List<ExceptionPostCall>();
+        public List<MinidumpPostCall> MinidumpCalls { get; } = new List<MinidumpPostCall>();
+
+        public FakeBugSplat(string database, string application, string version)
+            : base(database, application, version)
+        {
+        }
+
+        public override Task<HttpResponseMessage> Post(string stackTrace, ExceptionPostOptions options)
+        {
+            ExceptionCalls.Add(new ExceptionPostCall { StackTrace = stackTrace, Options = options });
+            return Task.FromResult(new HttpResponseMessage());
+        }
+
+        public override Task<HttpResponseMessage> Post(Exception ex, ExceptionPostOptions options)
+        {
+            ExceptionCalls.Add(new ExceptionPostCall { Exception = ex, Options = options });
+            return Task.FromResult(new HttpResponseMessage());
+        }
+
+        public override Task<HttpResponseMessage> Post(FileInfo minidumpFileInfo, MinidumpPostOptions options)
+        {
+            MinidumpCalls.Add(new MinidumpPostCall { MinidumpFileInfo = minidumpFileInfo, Options = options });
+            return Task.FromResult(new HttpResponseMessage());
+        }
+    }
+
+    class ExceptionPostCall
+    {
+        public string StackTrace { get; set; }
+        public Exception Exception { get; set; }
+        public ExceptionPostOptions Options { get; set; }
+    }
+
+    class MinidumpPostCall
+    {
+        public FileInfo MinidumpFileInfo { get; set; }
+        public MinidumpPostOptions Options { get; set; }
+    }
+}

--- a/Tests/Runtime/Client/Fakes/FakeBugSplat.cs.meta
+++ b/Tests/Runtime/Client/Fakes/FakeBugSplat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94bfcd3e6b084555a68691efe84e61f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- handle null options in DotNetStandardClient
- add tests covering default option creation when Post is called with null options

## Testing
- `echo "No tests to run" && true`