### PR TITLE
Fix README caret typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://github.com/BugSplat-Git/bugsplat-unity.git
 
 After installing `com.bugsplat.unity`, you can import a sample project to help you get started with BugSplat. Click here if you'd like to skip the sample project and get straight to the [usage](#usage) instructions.
 
-To import the sample, click the carrot next to **Samples** to reveal the **my-unity-crasher** sample. Click **Import** to add the sample to your project.
+To import the sample, click the caret next to **Samples** to reveal the **my-unity-crasher** sample. Click **Import** to add the sample to your project.
 
 ![Importing the Sample](https://github.com/BugSplat-Git/bugsplat-unity/assets/2646053/b7a39388-eb76-413a-a92f-72fd39c9a7d6)
 


### PR DESCRIPTION
## Summary
- update README to use the word "caret" when instructing how to import the sample

## Testing
- `grep -n "carrot" README.md`