### PR TITLE
fix(android): enable native crash reporting flag and wire supported setters

### DIFF
--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -312,6 +312,7 @@ namespace BugSplatUnity
                 
                 var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
                 javaClass.CallStatic("initBugSplat", activity, database, application, version);
+                nativeCrashReportingEnabled = true;
             }
 
             UseDotNetHandler(database, application, version);
@@ -525,11 +526,15 @@ namespace BugSplatUnity
             _setNativeAttributeMac(key, value);
 #elif UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetAttribute(key, value);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
+            javaClass.CallStatic("setAttribute", key, value);
 #endif
         }
 
         /// <summary>
         /// Set the user name on the native crash reporter.
+        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeUser(string user)
         {
@@ -545,6 +550,7 @@ namespace BugSplatUnity
 
         /// <summary>
         /// Set the user email on the native crash reporter.
+        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeEmail(string email)
         {
@@ -560,6 +566,7 @@ namespace BugSplatUnity
 
         /// <summary>
         /// Set notes on the native crash reporter.
+        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeNotes(string notes)
         {
@@ -665,6 +672,7 @@ namespace BugSplatUnity
 
         /// <summary>
         /// Attach a log file to native crash reports. The file is read and included when a crash is uploaded.
+        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void AttachNativeLogFile(string path)
         {

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -534,7 +534,6 @@ namespace BugSplatUnity
 
         /// <summary>
         /// Set the user name on the native crash reporter.
-        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeUser(string user)
         {
@@ -545,12 +544,14 @@ namespace BugSplatUnity
             _setNativeUserMac(user);
 #elif UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetUser(user);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
+            javaClass.CallStatic("setAttribute", "BugSplatUser", user);
 #endif
         }
 
         /// <summary>
         /// Set the user email on the native crash reporter.
-        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeEmail(string email)
         {
@@ -561,12 +562,14 @@ namespace BugSplatUnity
             _setNativeEmailMac(email);
 #elif UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetEmail(email);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
+            javaClass.CallStatic("setAttribute", "BugSplatEmail", email);
 #endif
         }
 
         /// <summary>
         /// Set notes on the native crash reporter.
-        /// Supported on Windows, iOS, and macOS; no-op on Android.
         /// </summary>
         public void SetNativeNotes(string notes)
         {
@@ -577,17 +580,23 @@ namespace BugSplatUnity
             _setNativeNotesMac(notes);
 #elif UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetNotes(notes);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
+            javaClass.CallStatic("setAttribute", "BugSplatNotes", notes);
 #endif
         }
 
         /// <summary>
-        /// Set the key on the native crash reporter. Windows only; no-op on other platforms.
+        /// Set the key on the native crash reporter. Supported on Windows and Android; no-op on iOS and macOS.
         /// </summary>
         public void SetNativeKey(string key)
         {
             if (!nativeCrashReportingEnabled) return;
 #if UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetKey(key);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
+            javaClass.CallStatic("setAttribute", "BugSplatApplicationKey", key);
 #endif
         }
 


### PR DESCRIPTION
> **Stacked PR:** this branch stacks on #123 (`feat/windows-native-crash-reporting`) and should merge into it, not `main`.

Fixes audit finding **A3** from the 5.0.0 SDK audit: on Android, `nativeCrashReportingEnabled` was never set, so every native setter silently no-oped.

## What was broken

- `Runtime/BugSplat.cs:250-315` — the Windows (`:255`), iOS (`:294`), and macOS (`:303`) init branches all set `nativeCrashReportingEnabled = true`, but the Android branch (`:308-315`) called `BugSplatBridge.initBugSplat` and never set the flag.
- `SetNativeAttribute` (`:521`), `SetNativeUser` (`:536`), `SetNativeEmail` (`:551`), and `SetNativeNotes` (`:566`) all begin with `if (!nativeCrashReportingEnabled) return;`, so on Android they always early-returned — including the attribute sync callback wired up in `UseDotNetHandler` (`:339-342`), meaning `bugsplat.Attributes[...] = ...` never reached the native reporter.
- Separately, none of those setters had an Android branch even if the flag had been set.

## What changed

- The Android init branch now sets `nativeCrashReportingEnabled = true` after `initBugSplat`, mirroring iOS/macOS (the bridge's `initBugSplat` returns `void`, so like those platforms there is no success result to branch on).
- `SetNativeAttribute` gained an Android branch that calls `BugSplatBridge.setAttribute(key, value)` via `AndroidJavaClass`, matching the interop style already used in the init branch.
- `SetNativeUser`, `SetNativeEmail`, `SetNativeNotes`, and `SetNativeKey` gained Android branches that route through reserved attribute names (see below). `SetNativeKey` mirrors the existing Windows native-key pathway (`Key` property → `SetNativeKey` → `BugSplat_SetKey`) that the sample relies on to split crash buckets.
- `AttachNativeLogFile` is documented as an Android no-op — the bridge only accepts attachments via `initBugSplat(..., String[] paths)` overloads, not post-init.

## How user/email/notes/key work without dedicated bridge methods

`BugSplatBridge` has no user/email/notes/key setters — its only post-init mutators are `setAttribute(String, String)` and `removeAttribute(String)` (verified by extracting `Runtime/Plugins/Android/bugsplat-android-release.aar` and parsing the `classes.jar` method tables; the underlying `com.bugsplat.android.BugSplat` class has none either).

Instead, the backend promotes reserved attribute names to first-class crash report fields for **any** minidump-based report. In src-backend `AdminTools/BugSplatService/CrashReport.cs`, `Analyze()` calls `SetAttributeOverrides()` (`:519-520`), defined at `:1295-1321`, which matches attribute keys with `Contains`:

| Reserved attribute name | Promoted to |
| --- | --- |
| `BugSplatUser` | User |
| `BugSplatEmail` | Email |
| `BugSplatApplicationKey` | Key |
| `BugSplatNotes` | Notes |

These names come from the backend's generic `SetAttributeOverrides` path — deliberately **not** the `UserName`/`UserEmail` names in the Unreal docs' Custom Fields table, which apply only to Unreal's CrashContext-XML parsing path, not the generic path Unity-Android minidumps go through.

On the SDK side, `bugsplat-android`'s `jniSetAttribute` stores each pair as a Crashpad `Annotation` registered with the process `AnnotationList`, which the crash handler reads at crash time, so the values arrive as report attributes and get promoted. `BugSplatBridge.setAttribute` also treats a `null` value as `removeAttribute`, so clearing a field via `Email = null` etc. is safe.

## Known quirks and follow-ups

- The backend's override matching uses `Contains`, so a user-defined attribute whose key merely contains a reserved name (e.g. `SetNativeAttribute("BugSplatUserFoo", ...)`) would collide with the promoted field. No code guards this; it is a backend matching quirk to be aware of.
- Proper first-class user/email/notes/key methods in `bugsplat-android`'s bridge would be the cleaner upstream fix later; this PR uses the attribute-promotion mechanism the current vendored `.aar` already supports.
- `AttachNativeLogFile` remains an Android no-op until the bridge grows a post-init attachment method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
