### PR TITLE
fix: compile Runtime and Tests assemblies on all build targets

### DIFF
--- a/Runtime/Settings/IClientSettingsRepository.cs
+++ b/Runtime/Settings/IClientSettingsRepository.cs
@@ -12,9 +12,7 @@ namespace BugSplatUnity.Runtime.Settings
         bool CapturePlayerLog { get; set; }
         bool CaptureScreenshots { get; set; }
         bool PostExceptionsInEditor { get; set; }
-#if !UNITY_WEBGL
         int LogFileMaxSizeMB { get; set; }
-#endif
         Func<Exception, bool> ShouldPostException { get; set; }
         string Description { get; set; }
         string Email { get; set; }

--- a/Runtime/Settings/WebGLClientSettingsRepository.cs
+++ b/Runtime/Settings/WebGLClientSettingsRepository.cs
@@ -5,7 +5,6 @@ using System.IO;
 
 namespace BugSplatUnity.Runtime.Settings
 {
-#if UNITY_WEBGL
     internal class WebGLClientSettingsRepository : IClientSettingsRepository
     {
         // TODO BG what do we do about attachments here...
@@ -15,6 +14,7 @@ namespace BugSplatUnity.Runtime.Settings
         public bool CaptureEditorLog { get; set; } = false;
         public bool CapturePlayerLog { get; set; } = false;
         public bool CaptureScreenshots { get; set; } = false;
+        public int LogFileMaxSizeMB { get; set; } = 10;
         public bool PostExceptionsInEditor { get; set; } = true;
         public Func<Exception, bool> ShouldPostException { get; set; } = ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl;
         public string Description { get; set; }
@@ -23,5 +23,4 @@ namespace BugSplatUnity.Runtime.Settings
         public string Notes { get; set; }
         public string User { get; set; }
     }
-#endif
 }


### PR DESCRIPTION
> **Note:** This PR stacks on #123 (`feat/windows-native-crash-reporting`) and targets that branch.

Fixes audit findings A1 and A2 from the 5.0.0 SDK audit: the Runtime assembly failed to compile whenever `UNITY_WEBGL` was defined, and the Tests assembly failed to compile whenever it was not.

## What was broken

**A1 — Runtime assembly did not compile under `UNITY_WEBGL`.** `IClientSettingsRepository.LogFileMaxSizeMB` was declared inside `#if !UNITY_WEBGL` (`Runtime/Settings/IClientSettingsRepository.cs:15-17`), but the member is used unconditionally:

- `Runtime/BugSplat.cs:162-172` — the public `LogFileMaxSizeMB` property forwards to `clientSettings.LogFileMaxSizeMB` with no guard (and `CreateFromOptions` assigns it at `Runtime/BugSplat.cs:373`).
- `Runtime/Reporter/DotNetStandardExceptionReporter.cs:95,116,137` — inside `#if UNITY_EDITOR_WIN / UNITY_EDITOR_OSX / UNITY_EDITOR_LINUX` blocks, which are active in the editor even when the active build target is WebGL (where `UNITY_WEBGL` is also defined).

So compilation broke both in a WebGL player build and in the editor with WebGL as the active build target.

**A2 — Tests assembly compiled only under `UNITY_WEBGL`.** `WebGLClientSettingsRepository` was declared inside `#if UNITY_WEBGL` (`Runtime/Settings/WebGLClientSettingsRepository.cs:8-26`), but three test files instantiate it with no guard (the Tests assembly contains zero preprocessor directives):

- `Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs:25,45,72,92,129,174`
- `Tests/Runtime/Reporter/WebGLReporterTests.cs:24,46,70,91,122,160`
- `Tests/Runtime/Reporter/ReportUploadGuardServiceTests.cs:14,26,38,49,60,80,92,104,124`

Its sibling WebGL classes (`WebGLReporter`, `WebGLExceptionClient`) were already compiled unconditionally — only the settings repository was gated.

## The fix

- `Runtime/Settings/IClientSettingsRepository.cs` — dropped the `#if !UNITY_WEBGL` guard so `LogFileMaxSizeMB` exists on every target.
- `Runtime/Settings/WebGLClientSettingsRepository.cs` — dropped the `#if UNITY_WEBGL` guard so the class (a plain POCO) compiles everywhere, and implemented `LogFileMaxSizeMB` with the same `10` default as `DotNetStandardClientSettingsRepository`. The WebGL reporter never reads the value, so WebGL behavior is unchanged. Platform *wiring* stays gated: `Runtime/BugSplat.cs:284-289` still selects the WebGL repository only inside `#elif UNITY_WEBGL`.

Net diff: 1 insertion, 4 deletions.

## Verification (by inspection)

Both `.asmdef` files were checked: `Runtime/BugSplat.Unity.Runtime.asmdef` declares no `includePlatforms`/`excludePlatforms`/`defineConstraints` (compiles on every target), and `Tests/BugSplat.Unity.RuntimeTests.asmdef` has empty `includePlatforms`/`excludePlatforms` with only the `UNITY_INCLUDE_TESTS` constraint (compiles on every target whenever tests are included). So all four compilation contexts matter for both assemblies.

Every declaration/use pair involving a conditional symbol was hand-checked across the four contexts:

| Symbol (declaration scope after fix) | Use sites (scope) | WebGL player | Non-WebGL player | Editor, WebGL target | Editor, non-WebGL target |
|---|---|---|---|---|---|
| `IClientSettingsRepository.LogFileMaxSizeMB` (unconditional) | `BugSplat.cs:161-171,373` (unconditional); `DotNetStandardExceptionReporter.cs:95,116,137` (`UNITY_EDITOR_*`); `:166,187,208,229` (`UNITY_STANDALONE_*`/`UNITY_WSA`) | OK (was: error) | OK | OK (was: error) | OK |
| `DotNetStandardClientSettingsRepository.LogFileMaxSizeMB` (unconditional) | interface implementation | OK | OK | OK | OK |
| `WebGLClientSettingsRepository` (unconditional) | `BugSplat.cs:285` (`UNITY_WEBGL`); 21 unguarded test call sites | OK | OK (was: error in Tests) | OK | OK (was: error in Tests) |
| `WebGLReporter`, `WebGLExceptionClient` (unconditional, pre-existing) | `BugSplat.cs:286-287` (`UNITY_WEBGL`); unguarded tests | OK | OK | OK | OK |
| `SHGetKnownFolderPath` / `GetKnownFolderPath` (`UNITY_STANDALONE_WIN`, `DotNetStandardExceptionReporter.cs:379-399`) | `:159` (`UNITY_STANDALONE_WIN`) | OK | OK | OK | OK |
| Native externs in `BugSplat.cs:681-764` (per-platform `&& !UNITY_EDITOR` gates) | call sites in matching per-platform `&& !UNITY_EDITOR` gates (`:250-320,522-663`) | OK | OK | OK | OK |

After the change no symbol in either assembly is declared in a narrower `#if` scope than any of its uses. The Tests assembly references no conditionally-compiled Runtime symbol anymore. The `Editor` assembly references neither `LogFileMaxSizeMB` nor `WebGLClientSettingsRepository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
