### PR TITLE
fix: await report uploads and invoke callbacks on the main thread

### DIFF
--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -263,42 +263,49 @@ namespace BugSplatUnity.Runtime.Reporter
                 }
             }
 
-            yield return Task.Run(
+            var task = Task.Run(
                 async () =>
                 {
-                    try
-                    {
-                        var result = await exceptionClient.Post(stackTrace, options);
-                        var status = result.StatusCode;
-                        var contents = await result.Content.ReadAsStringAsync();
-                        var uploaded = status == System.Net.HttpStatusCode.OK;
-                        var message = uploaded ? "Crash successfully uploaded to BugSplat!" : $"BugSplat upload failed with code {status}";
-                        var response = JsonUtility.FromJson<BugSplatResponse>(contents);
-                        Debug.Log($"BugSplat info: status {status}\n {contents}");
-                        callback?.Invoke(new ExceptionReporterPostResult()
-                        {
-                            Uploaded = uploaded,
-                            Exception = stackTrace,
-                            Message = message,
-                            Response = response
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogError($"BugSplat error: {ex}");
-                        callback?.Invoke(new ExceptionReporterPostResult()
-                        {
-                            Uploaded = false,
-                            Exception = stackTrace,
-                            Message = $"BugSplat upload failed with exception: {ex}",
-                        });
-                    }
-                    finally
-                    {
-                        DeleteTempFiles(tempFiles);
-                    }
+                    var result = await exceptionClient.Post(stackTrace, options);
+                    var contents = await result.Content.ReadAsStringAsync();
+                    return new KeyValuePair<System.Net.HttpStatusCode, string>(result.StatusCode, contents);
                 }
             );
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            DeleteTempFiles(tempFiles);
+
+            try
+            {
+                var result = task.GetAwaiter().GetResult();
+                var status = result.Key;
+                var contents = result.Value;
+                var uploaded = status == System.Net.HttpStatusCode.OK;
+                var message = uploaded ? "Crash successfully uploaded to BugSplat!" : $"BugSplat upload failed with code {status}";
+                var response = JsonUtility.FromJson<BugSplatResponse>(contents);
+                Debug.Log($"BugSplat info: status {status}\n {contents}");
+                callback?.Invoke(new ExceptionReporterPostResult()
+                {
+                    Uploaded = uploaded,
+                    Exception = stackTrace,
+                    Message = message,
+                    Response = response
+                });
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"BugSplat error: {ex}");
+                callback?.Invoke(new ExceptionReporterPostResult()
+                {
+                    Uploaded = false,
+                    Exception = stackTrace,
+                    Message = $"BugSplat upload failed with exception: {ex}",
+                });
+            }
         }
 
         // Copy to a temp file to avoid sharing exception

--- a/Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs
+++ b/Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs
@@ -100,7 +100,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             };
             var httpResponseMessage = new HttpResponseMessage
             {
-                Content = new StringContent(string.Empty)
+                Content = new StringContent("{}")
             };
             var fakeExceptionClient = new FakeDotNetExceptionClient(httpResponseMessage);
             var sut = new DotNetStandardExceptionReporter(clientSettings, fakeExceptionClient)
@@ -145,7 +145,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             };
             var httpResponseMessage = new HttpResponseMessage
             {
-                Content = new StringContent(string.Empty)
+                Content = new StringContent("{}")
             };
             var fakeExceptionClient = new FakeDotNetExceptionClient(httpResponseMessage);
             var sut = new DotNetStandardExceptionReporter(clientSettings, fakeExceptionClient)
@@ -177,7 +177,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             };
             var httpResponseMessage = new HttpResponseMessage
             {
-                Content = new StringContent(string.Empty)
+                Content = new StringContent("{}")
             };
             var fakeExceptionClient = new FakeDotNetExceptionClient(httpResponseMessage);
             var sut = new DotNetStandardExceptionReporter(clientSettings, fakeExceptionClient)


### PR DESCRIPTION
> **Note:** This PR stacks on #123 (`feat/windows-native-crash-reporting`) and targets that branch.

Fixes audit findings **A4** and **A5** from the 5.0.0 SDK audit in `Runtime/Reporter/DotNetStandardExceptionReporter.cs`.

## What was broken

**A4 — `yield return Task.Run(...)` does not await** (`Runtime/Reporter/DotNetStandardExceptionReporter.cs:266-301` before this change). Unity's coroutine scheduler treats an unknown yielded object as "wait one frame", so the upload task ran unsupervised and the coroutine completed immediately. A caller doing `yield return bugsplat.Post(ex); Application.Quit();` lost reports nondeterministically.

**A5 — Callbacks and response parsing ran on a threadpool thread** (`Runtime/Reporter/DotNetStandardExceptionReporter.cs:271-294` before this change). `JsonUtility.FromJson`, `Debug.Log`/`Debug.LogError`, and `callback?.Invoke` all executed inside the `Task.Run` body. A user callback touching any Unity API would throw.

## The fix

Keep only the network I/O (`exceptionClient.Post` + `ReadAsStringAsync`) inside the task. Poll `task.IsCompleted` the way `Runtime/BugSplat.cs:456` (`PostFeedback`) and `Runtime/BugSplat.cs:496` (minidump `Post`) already do, then do response parsing, logging, and callback invocation on the coroutine (main) thread. Faulted or canceled tasks are rethrown by `task.GetAwaiter().GetResult()` into the method's pre-existing catch block, so the error log format and failure callback contract are unchanged.

### Before

```
Post coroutine
 ├─ yield return Task.Run(post + parse + log + callback)   <- treated as "wait one frame"
 └─ coroutine ends immediately; task keeps running on threadpool
        └─ parse/log/callback on threadpool thread
```

### After

```
Post coroutine
 ├─ task = Task.Run(post + read response body)             <- network I/O only
 ├─ while (!task.IsCompleted) yield return null;           <- coroutine genuinely waits
 ├─ DeleteTempFiles(tempFiles)
 └─ parse + log + callback on the main thread
      └─ faulted task -> GetResult() rethrows -> existing catch -> existing failure callback
```

## Code paths hand-checked

- Guard-skip early returns in `LogMessageReceived` and `Post(Exception, ...)` — untouched; skip callback still invoked synchronously.
- Exceptions thrown before the task is created (editor/player log capture, screenshot capture) — each already has local handling; unchanged.
- Faulted task — `GetAwaiter().GetResult()` rethrows the original (unwrapped) exception into the same catch, producing the identical `BugSplat error: {ex}` log and `BugSplat upload failed with exception: {ex}` failure callback, now on the main thread.
- Canceled task — `TaskCanceledException` takes the same catch path, matching the old behavior where it was caught inside the lambda.
- `JsonUtility.FromJson` parse failure — same catch path and failure callback as before, now on the main thread.
- Null callback — `callback?.Invoke` preserved everywhere.
- Temp files — still deleted unconditionally once the upload completes.

## Test updates

Three tests in `Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs` fed the fake response `StringContent(string.Empty)`, which makes `JsonUtility.FromJson` throw. They only stayed green because the resulting `Debug.LogError` fired on a threadpool thread inside the unsupervised task, escaping the test framework's log assertions. With the error path now on the main thread that log would fail them, so they use `StringContent("{}")` like the existing `LogMessageReceived` test in the same file — their assertions (options passed through, callback invoked) are unchanged. The tests' `AsCoroutine()`-based awaiting still works: callbacks now fire before the `Post` coroutine returns, so the completion task is simply already started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
