### PR TITLE
fix: keep symbol upload credentials out of builds, Xcode projects, and process args

### DIFF
--- a/Editor/BugSplatOptionsEditor.cs
+++ b/Editor/BugSplatOptionsEditor.cs
@@ -10,7 +10,7 @@ public class BugSplatOptionsEditor : Editor
     private const string integrationsText = "<color=#040404>A Client ID and Client Secret pair can be generated on the BugSplat <a>Integrations</a> page.</color>";
     private const string integrationsQueryString = "?database={0}";
     private const string emptyDatabaseErrorMessage = "Database cannot be null or empty!";
-    private const string credentialsWarningMessage = "Symbol upload credentials saved in this asset are stored in plain text and can end up in version control. Prefer the BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET environment variables, which override these values. Values saved here are removed from the asset while a player build runs and restored when it finishes.";
+    private const string credentialsWarningMessage = "Symbol upload credentials saved in this asset are stored in plain text and can end up in version control. Prefer the SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET environment variables, which override these values. Values saved here are removed from the asset while a player build runs and restored when it finishes.";
 
     private const int integrationsPaddingTop = 5;
     private const int integrationsPaddingBottom = 5;

--- a/Editor/BugSplatOptionsEditor.cs
+++ b/Editor/BugSplatOptionsEditor.cs
@@ -10,7 +10,7 @@ public class BugSplatOptionsEditor : Editor
     private const string integrationsText = "<color=#040404>A Client ID and Client Secret pair can be generated on the BugSplat <a>Integrations</a> page.</color>";
     private const string integrationsQueryString = "?database={0}";
     private const string emptyDatabaseErrorMessage = "Database cannot be null or empty!";
-    private const string credentialsWarningMessage = "Symbol upload credentials saved in this asset are stored in plain text and can end up in version control. Prefer the SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET environment variables, which override these values. Values saved here are removed from the asset while a player build runs and restored when it finishes.";
+    private const string credentialsInfoMessage = "Symbol upload credentials are not stored here — they would end up in version control and in your builds. Set them per database via BugSplat > Symbol Upload > Set Credentials, or with the SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET environment variables.";
 
     private const int integrationsPaddingTop = 5;
     private const int integrationsPaddingBottom = 5;
@@ -33,52 +33,38 @@ public class BugSplatOptionsEditor : Editor
         while (iterator.NextVisible(traverseChildren))
         {
             traverseChildren = false;
-            if (string.Equals(iterator.name, nameof(options.SymbolUploadClientId)))
-            {
-                var queryString = !string.IsNullOrEmpty(options.Database)
-                    ? string.Format(integrationsQueryString, options.Database)
-                    : string.Empty;
-                var integrationsURL = string.Format(integrationsURLFormat, queryString);
-
-                var style = new GUIStyle()
-                {
-                    richText = true,
-                    wordWrap = true,
-                    margin = new RectOffset(0, 0, integrationsPaddingTop, integrationsPaddingBottom)
-                };
-
-                if (GUILayout.Button(integrationsText, style))
-                {
-                    Application.OpenURL(integrationsURL);
-                }
-
-                var rect = GUILayoutUtility.GetLastRect();
-                rect.width = style.CalcSize(new GUIContent(integrationsText)).x;
-                EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
-            }
-
-            var property = serializedObject.FindProperty(iterator.name);
-            if (string.Equals(iterator.name, nameof(options.SymbolUploadClientId))
-                || string.Equals(iterator.name, nameof(options.SymbolUploadClientSecret)))
-            {
-                var label = new GUIContent(property.displayName, property.tooltip);
-                property.stringValue = EditorGUILayout.PasswordField(label, property.stringValue);
-                continue;
-            }
-
-            EditorGUILayout.PropertyField(property, true);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty(iterator.name), true);
         }
 
         serializedObject.ApplyModifiedProperties();
-
-        if (!string.IsNullOrEmpty(options.SymbolUploadClientId) || !string.IsNullOrEmpty(options.SymbolUploadClientSecret))
-        {
-            EditorGUILayout.HelpBox(credentialsWarningMessage, MessageType.Warning);
-        }
 
         if (string.IsNullOrEmpty(options.Database))
         {
             EditorGUILayout.HelpBox(emptyDatabaseErrorMessage, MessageType.Error);
         }
+
+        EditorGUILayout.Space();
+        EditorGUILayout.HelpBox(credentialsInfoMessage, MessageType.Info);
+
+        var queryString = !string.IsNullOrEmpty(options.Database)
+            ? string.Format(integrationsQueryString, options.Database)
+            : string.Empty;
+        var integrationsURL = string.Format(integrationsURLFormat, queryString);
+
+        var style = new GUIStyle()
+        {
+            richText = true,
+            wordWrap = true,
+            margin = new RectOffset(0, 0, integrationsPaddingTop, integrationsPaddingBottom)
+        };
+
+        if (GUILayout.Button(integrationsText, style))
+        {
+            Application.OpenURL(integrationsURL);
+        }
+
+        var rect = GUILayoutUtility.GetLastRect();
+        rect.width = style.CalcSize(new GUIContent(integrationsText)).x;
+        EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
     }
 }

--- a/Editor/BugSplatOptionsEditor.cs
+++ b/Editor/BugSplatOptionsEditor.cs
@@ -10,6 +10,7 @@ public class BugSplatOptionsEditor : Editor
     private const string integrationsText = "<color=#040404>A Client ID and Client Secret pair can be generated on the BugSplat <a>Integrations</a> page.</color>";
     private const string integrationsQueryString = "?database={0}";
     private const string emptyDatabaseErrorMessage = "Database cannot be null or empty!";
+    private const string credentialsWarningMessage = "Symbol upload credentials saved in this asset are stored in plain text and can end up in version control. Prefer the BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET environment variables, which override these values. Values saved here are removed from the asset while a player build runs and restored when it finishes.";
 
     private const int integrationsPaddingTop = 5;
     private const int integrationsPaddingBottom = 5;
@@ -57,10 +58,23 @@ public class BugSplatOptionsEditor : Editor
             }
 
             var property = serializedObject.FindProperty(iterator.name);
+            if (string.Equals(iterator.name, nameof(options.SymbolUploadClientId))
+                || string.Equals(iterator.name, nameof(options.SymbolUploadClientSecret)))
+            {
+                var label = new GUIContent(property.displayName, property.tooltip);
+                property.stringValue = EditorGUILayout.PasswordField(label, property.stringValue);
+                continue;
+            }
+
             EditorGUILayout.PropertyField(property, true);
         }
 
         serializedObject.ApplyModifiedProperties();
+
+        if (!string.IsNullOrEmpty(options.SymbolUploadClientId) || !string.IsNullOrEmpty(options.SymbolUploadClientSecret))
+        {
+            EditorGUILayout.HelpBox(credentialsWarningMessage, MessageType.Warning);
+        }
 
         if (string.IsNullOrEmpty(options.Database))
         {

--- a/Editor/BugSplatSymbolUploadCredentials.cs
+++ b/Editor/BugSplatSymbolUploadCredentials.cs
@@ -13,8 +13,9 @@ using UnityEditor.Build.Reporting;
 /// </summary>
 public class BugSplatSymbolUploadCredentials : IPreprocessBuildWithReport, IPostprocessBuildWithReport
 {
-	const string ClientIdEnvironmentVariable = "BUGSPLAT_CLIENT_ID";
-	const string ClientSecretEnvironmentVariable = "BUGSPLAT_CLIENT_SECRET";
+	// The same names the symbol-upload CLI reads, so nothing has to be remapped on the way down.
+	const string ClientIdEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_ID";
+	const string ClientSecretEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_SECRET";
 	const string ClientIdSessionKey = "BugSplat.SymbolUploadClientId";
 	const string ClientSecretSessionKey = "BugSplat.SymbolUploadClientSecret";
 	const string RestorePendingSessionKey = "BugSplat.SymbolUploadCredentialsRestorePending";
@@ -52,8 +53,8 @@ public class BugSplatSymbolUploadCredentials : IPreprocessBuildWithReport, IPost
 	}
 
 	/// <summary>
-	/// Resolves the symbol upload Client ID. The BUGSPLAT_CLIENT_ID environment variable is the
-	/// recommended source and takes precedence; the options asset and the value cached during
+	/// Resolves the symbol upload Client ID. The SYMBOL_UPLOAD_CLIENT_ID environment variable is
+	/// the recommended source and takes precedence; the options asset and the value cached during
 	/// build preprocessing are fallbacks.
 	/// </summary>
 	internal static string GetClientId(BugSplatOptions options)
@@ -69,9 +70,9 @@ public class BugSplatSymbolUploadCredentials : IPreprocessBuildWithReport, IPost
 	}
 
 	/// <summary>
-	/// Resolves the symbol upload Client Secret. The BUGSPLAT_CLIENT_SECRET environment variable
-	/// is the recommended source and takes precedence; the options asset and the value cached
-	/// during build preprocessing are fallbacks.
+	/// Resolves the symbol upload Client Secret. The SYMBOL_UPLOAD_CLIENT_SECRET environment
+	/// variable is the recommended source and takes precedence; the options asset and the value
+	/// cached during build preprocessing are fallbacks.
 	/// </summary>
 	internal static string GetClientSecret(BugSplatOptions options)
 	{

--- a/Editor/BugSplatSymbolUploadCredentials.cs
+++ b/Editor/BugSplatSymbolUploadCredentials.cs
@@ -1,120 +1,163 @@
 using System;
-using BugSplatUnity.Runtime.Client;
-using UnityEditor;
-using UnityEditor.Build;
-using UnityEditor.Build.Reporting;
+using System.IO;
+using System.Text.RegularExpressions;
 
 /// <summary>
-/// Keeps symbol upload credentials out of built players. Before a player build serializes the
-/// BugSplatOptions asset, the OAuth2 Client ID and Client Secret are cached in SessionState and
-/// blanked on the asset; they are restored after the build completes. If the build throws before
-/// the post-build callback runs, the values are restored by the next editor update tick, the next
-/// domain reload, or editor shutdown, whichever happens first.
+/// Resolves symbol upload credentials, which are per-database and machine-local.
+///
+/// They are never stored in the project: an asset carrying them ends up in version control and in
+/// shipped player builds, which is what this replaces. Instead they live in the user's home
+/// directory, one file per BugSplat database, in the shell format the symbol-upload CLI already
+/// understands so the generated Xcode build phase can source the same file directly.
 /// </summary>
-public class BugSplatSymbolUploadCredentials : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+public static class BugSplatSymbolUploadCredentials
 {
-	// The same names the symbol-upload CLI reads, so nothing has to be remapped on the way down.
-	const string ClientIdEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_ID";
-	const string ClientSecretEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_SECRET";
-	const string ClientIdSessionKey = "BugSplat.SymbolUploadClientId";
-	const string ClientSecretSessionKey = "BugSplat.SymbolUploadClientSecret";
-	const string RestorePendingSessionKey = "BugSplat.SymbolUploadCredentialsRestorePending";
+	// The names the symbol-upload CLI reads, so nothing has to be remapped on the way down.
+	public const string ClientIdEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_ID";
+	public const string ClientSecretEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_SECRET";
 
-	public int callbackOrder => 0;
+	const string CredentialsDirectoryName = ".bugsplat";
+	const string CredentialsSubdirectoryName = "credentials";
 
-	public void OnPreprocessBuild(BuildReport report)
+	/// <summary>
+	/// Absolute path to the credentials file for a database. Shared with the generated Xcode build
+	/// phase, which resolves the same path against $HOME.
+	/// </summary>
+	public static string GetCredentialsPath(string database)
 	{
-		var options = BuildPostprocessors.GetBugSplatOptions();
-		if (options == null)
-			return;
-
-		SessionState.SetString(ClientIdSessionKey, options.SymbolUploadClientId ?? string.Empty);
-		SessionState.SetString(ClientSecretSessionKey, options.SymbolUploadClientSecret ?? string.Empty);
-
-		if (string.IsNullOrEmpty(options.SymbolUploadClientId) && string.IsNullOrEmpty(options.SymbolUploadClientSecret))
-			return;
-
-		SessionState.SetBool(RestorePendingSessionKey, true);
-
-		EditorApplication.update -= RestoreOnEditorUpdate;
-		EditorApplication.update += RestoreOnEditorUpdate;
-		EditorApplication.quitting -= Restore;
-		EditorApplication.quitting += Restore;
-
-		options.SymbolUploadClientId = string.Empty;
-		options.SymbolUploadClientSecret = string.Empty;
-		EditorUtility.SetDirty(options);
-		AssetDatabase.SaveAssetIfDirty(options);
-	}
-
-	public void OnPostprocessBuild(BuildReport report)
-	{
-		Restore();
+		var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		return Path.Combine(home, CredentialsDirectoryName, CredentialsSubdirectoryName, $"{SanitizeDatabase(database)}.sh");
 	}
 
 	/// <summary>
-	/// Resolves the symbol upload Client ID. The SYMBOL_UPLOAD_CLIENT_ID environment variable is
-	/// the recommended source and takes precedence; the options asset and the value cached during
-	/// build preprocessing are fallbacks.
+	/// The path the Xcode build phase uses, expressed relative to $HOME so the generated script
+	/// carries no absolute path from the machine that ran the Unity build.
 	/// </summary>
-	internal static string GetClientId(BugSplatOptions options)
-	{
-		var clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable);
-		if (string.IsNullOrEmpty(clientId))
-			clientId = options.SymbolUploadClientId;
-
-		if (string.IsNullOrEmpty(clientId))
-			clientId = SessionState.GetString(ClientIdSessionKey, string.Empty);
-
-		return clientId;
-	}
+	public static string GetCredentialsPathRelativeToHome(string database)
+		=> $"{CredentialsDirectoryName}/{CredentialsSubdirectoryName}/{SanitizeDatabase(database)}.sh";
 
 	/// <summary>
-	/// Resolves the symbol upload Client Secret. The SYMBOL_UPLOAD_CLIENT_SECRET environment
-	/// variable is the recommended source and takes precedence; the options asset and the value
-	/// cached during build preprocessing are fallbacks.
+	/// Resolves credentials for a database: the environment wins, then the credentials file.
+	/// Returns false when neither supplies both values.
 	/// </summary>
-	internal static string GetClientSecret(BugSplatOptions options)
+	public static bool TryResolve(string database, out string clientId, out string clientSecret)
 	{
-		var clientSecret = Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable);
+		clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable);
+		clientSecret = Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable);
+
+		if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+		{
+			return true;
+		}
+
+		var stored = Read(database);
+		if (string.IsNullOrEmpty(clientId))
+		{
+			clientId = stored.clientId;
+		}
+
 		if (string.IsNullOrEmpty(clientSecret))
-			clientSecret = options.SymbolUploadClientSecret;
+		{
+			clientSecret = stored.clientSecret;
+		}
 
-		if (string.IsNullOrEmpty(clientSecret))
-			clientSecret = SessionState.GetString(ClientSecretSessionKey, string.Empty);
-
-		return clientSecret;
+		return !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret);
 	}
 
-	internal static bool EnvironmentHasCredentials =>
-		!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable))
-		&& !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable));
+	public static bool Exists(string database) => File.Exists(GetCredentialsPath(database));
 
-	[InitializeOnLoadMethod]
-	static void RestoreAfterDomainReload()
+	public static (string clientId, string clientSecret) Read(string database)
 	{
-		Restore();
+		var path = GetCredentialsPath(database);
+		if (!File.Exists(path))
+		{
+			return (string.Empty, string.Empty);
+		}
+
+		string id = string.Empty, secret = string.Empty;
+		foreach (var line in File.ReadAllLines(path))
+		{
+			var match = Regex.Match(line.Trim(), @"^export\s+(\w+)='(.*)'$");
+			if (!match.Success)
+			{
+				continue;
+			}
+
+			// Undo the POSIX single-quote escaping applied by Write.
+			var value = match.Groups[2].Value.Replace("'\\''", "'");
+			if (match.Groups[1].Value == ClientIdEnvironmentVariable)
+			{
+				id = value;
+			}
+			else if (match.Groups[1].Value == ClientSecretEnvironmentVariable)
+			{
+				secret = value;
+			}
+		}
+
+		return (id, secret);
 	}
 
-	static void RestoreOnEditorUpdate()
+	public static void Write(string database, string clientId, string clientSecret)
 	{
-		EditorApplication.update -= RestoreOnEditorUpdate;
-		Restore();
+		var path = GetCredentialsPath(database);
+		Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+		File.WriteAllText(
+			path,
+			$"# BugSplat symbol upload credentials for the '{database}' database.\n" +
+			"# Machine-local and not part of any project. Delete this file to revoke it here.\n" +
+			$"export {ClientIdEnvironmentVariable}='{EscapeShellSingleQuoted(clientId)}'\n" +
+			$"export {ClientSecretEnvironmentVariable}='{EscapeShellSingleQuoted(clientSecret)}'\n");
+
+		RestrictToOwner(path);
 	}
 
-	static void Restore()
+	public static bool Clear(string database)
 	{
-		if (!SessionState.GetBool(RestorePendingSessionKey, false))
+		var path = GetCredentialsPath(database);
+		if (!File.Exists(path))
+		{
+			return false;
+		}
+
+		File.Delete(path);
+		return true;
+	}
+
+	// Database names are subdomains of bugsplat.com, so this should never alter a real one - it is
+	// here so a malformed value cannot escape the credentials directory.
+	static string SanitizeDatabase(string database)
+	{
+		if (string.IsNullOrWhiteSpace(database))
+		{
+			return "unknown";
+		}
+
+		return Regex.Replace(database.Trim(), @"[^A-Za-z0-9_.-]", "_");
+	}
+
+	static string EscapeShellSingleQuoted(string value) => (value ?? string.Empty).Replace("'", "'\\''");
+
+	static void RestrictToOwner(string path)
+	{
+		if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
+		{
 			return;
+		}
 
-		var options = BuildPostprocessors.GetBugSplatOptions();
-		if (options == null)
-			return;
-
-		options.SymbolUploadClientId = SessionState.GetString(ClientIdSessionKey, string.Empty);
-		options.SymbolUploadClientSecret = SessionState.GetString(ClientSecretSessionKey, string.Empty);
-		EditorUtility.SetDirty(options);
-		AssetDatabase.SaveAssetIfDirty(options);
-		SessionState.SetBool(RestorePendingSessionKey, false);
+		try
+		{
+			var chmod = new System.Diagnostics.ProcessStartInfo("/bin/chmod", $"600 \"{path}\"")
+			{
+				UseShellExecute = false,
+				CreateNoWindow = true
+			};
+			System.Diagnostics.Process.Start(chmod)?.WaitForExit();
+		}
+		catch (Exception ex)
+		{
+			UnityEngine.Debug.LogWarning($"BugSplat: could not restrict permissions on {path}: {ex.Message}");
+		}
 	}
 }

--- a/Editor/BugSplatSymbolUploadCredentials.cs
+++ b/Editor/BugSplatSymbolUploadCredentials.cs
@@ -1,0 +1,119 @@
+using System;
+using BugSplatUnity.Runtime.Client;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+/// <summary>
+/// Keeps symbol upload credentials out of built players. Before a player build serializes the
+/// BugSplatOptions asset, the OAuth2 Client ID and Client Secret are cached in SessionState and
+/// blanked on the asset; they are restored after the build completes. If the build throws before
+/// the post-build callback runs, the values are restored by the next editor update tick, the next
+/// domain reload, or editor shutdown, whichever happens first.
+/// </summary>
+public class BugSplatSymbolUploadCredentials : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+{
+	const string ClientIdEnvironmentVariable = "BUGSPLAT_CLIENT_ID";
+	const string ClientSecretEnvironmentVariable = "BUGSPLAT_CLIENT_SECRET";
+	const string ClientIdSessionKey = "BugSplat.SymbolUploadClientId";
+	const string ClientSecretSessionKey = "BugSplat.SymbolUploadClientSecret";
+	const string RestorePendingSessionKey = "BugSplat.SymbolUploadCredentialsRestorePending";
+
+	public int callbackOrder => 0;
+
+	public void OnPreprocessBuild(BuildReport report)
+	{
+		var options = BuildPostprocessors.GetBugSplatOptions();
+		if (options == null)
+			return;
+
+		SessionState.SetString(ClientIdSessionKey, options.SymbolUploadClientId ?? string.Empty);
+		SessionState.SetString(ClientSecretSessionKey, options.SymbolUploadClientSecret ?? string.Empty);
+
+		if (string.IsNullOrEmpty(options.SymbolUploadClientId) && string.IsNullOrEmpty(options.SymbolUploadClientSecret))
+			return;
+
+		SessionState.SetBool(RestorePendingSessionKey, true);
+
+		EditorApplication.update -= RestoreOnEditorUpdate;
+		EditorApplication.update += RestoreOnEditorUpdate;
+		EditorApplication.quitting -= Restore;
+		EditorApplication.quitting += Restore;
+
+		options.SymbolUploadClientId = string.Empty;
+		options.SymbolUploadClientSecret = string.Empty;
+		EditorUtility.SetDirty(options);
+		AssetDatabase.SaveAssetIfDirty(options);
+	}
+
+	public void OnPostprocessBuild(BuildReport report)
+	{
+		Restore();
+	}
+
+	/// <summary>
+	/// Resolves the symbol upload Client ID. The BUGSPLAT_CLIENT_ID environment variable is the
+	/// recommended source and takes precedence; the options asset and the value cached during
+	/// build preprocessing are fallbacks.
+	/// </summary>
+	internal static string GetClientId(BugSplatOptions options)
+	{
+		var clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable);
+		if (string.IsNullOrEmpty(clientId))
+			clientId = options.SymbolUploadClientId;
+
+		if (string.IsNullOrEmpty(clientId))
+			clientId = SessionState.GetString(ClientIdSessionKey, string.Empty);
+
+		return clientId;
+	}
+
+	/// <summary>
+	/// Resolves the symbol upload Client Secret. The BUGSPLAT_CLIENT_SECRET environment variable
+	/// is the recommended source and takes precedence; the options asset and the value cached
+	/// during build preprocessing are fallbacks.
+	/// </summary>
+	internal static string GetClientSecret(BugSplatOptions options)
+	{
+		var clientSecret = Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable);
+		if (string.IsNullOrEmpty(clientSecret))
+			clientSecret = options.SymbolUploadClientSecret;
+
+		if (string.IsNullOrEmpty(clientSecret))
+			clientSecret = SessionState.GetString(ClientSecretSessionKey, string.Empty);
+
+		return clientSecret;
+	}
+
+	internal static bool EnvironmentHasCredentials =>
+		!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable))
+		&& !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable));
+
+	[InitializeOnLoadMethod]
+	static void RestoreAfterDomainReload()
+	{
+		Restore();
+	}
+
+	static void RestoreOnEditorUpdate()
+	{
+		EditorApplication.update -= RestoreOnEditorUpdate;
+		Restore();
+	}
+
+	static void Restore()
+	{
+		if (!SessionState.GetBool(RestorePendingSessionKey, false))
+			return;
+
+		var options = BuildPostprocessors.GetBugSplatOptions();
+		if (options == null)
+			return;
+
+		options.SymbolUploadClientId = SessionState.GetString(ClientIdSessionKey, string.Empty);
+		options.SymbolUploadClientSecret = SessionState.GetString(ClientSecretSessionKey, string.Empty);
+		EditorUtility.SetDirty(options);
+		AssetDatabase.SaveAssetIfDirty(options);
+		SessionState.SetBool(RestorePendingSessionKey, false);
+	}
+}

--- a/Editor/BugSplatSymbolUploadCredentials.cs.meta
+++ b/Editor/BugSplatSymbolUploadCredentials.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92e71153fe6d428a879c6940d9ac68f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/BugSplatSymbolUploadMenu.cs
+++ b/Editor/BugSplatSymbolUploadMenu.cs
@@ -1,0 +1,109 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace BugSplatUnity.Editor
+{
+	/// <summary>
+	/// Sets the machine-local symbol upload credentials for a BugSplat database. Credentials are
+	/// per-database rather than per-project, so one entry serves every project using that database.
+	/// </summary>
+	public class BugSplatSymbolUploadCredentialsWindow : EditorWindow
+	{
+		string database = string.Empty;
+		string clientId = string.Empty;
+		string clientSecret = string.Empty;
+
+		[MenuItem("BugSplat/Symbol Upload/Set Credentials...", false, 100)]
+		static void Open()
+		{
+			var window = GetWindow<BugSplatSymbolUploadCredentialsWindow>(true, "BugSplat Symbol Upload Credentials", true);
+			window.minSize = new Vector2(460, 260);
+			window.database = BuildPostprocessors.GetBugSplatOptions()?.Database ?? string.Empty;
+
+			if (!string.IsNullOrEmpty(window.database))
+			{
+				var existing = BugSplatSymbolUploadCredentials.Read(window.database);
+				window.clientId = existing.clientId;
+				window.clientSecret = existing.clientSecret;
+			}
+
+			window.ShowUtility();
+		}
+
+		[MenuItem("BugSplat/Symbol Upload/Clear Credentials", false, 101)]
+		static void ClearCredentials()
+		{
+			var database = BuildPostprocessors.GetBugSplatOptions()?.Database;
+			if (string.IsNullOrEmpty(database))
+			{
+				EditorUtility.DisplayDialog("BugSplat", "No BugSplatOptions asset with a database was found in this project.", "OK");
+				return;
+			}
+
+			if (!EditorUtility.DisplayDialog("BugSplat", $"Delete the stored symbol upload credentials for '{database}'?", "Delete", "Cancel"))
+			{
+				return;
+			}
+
+			var message = BugSplatSymbolUploadCredentials.Clear(database)
+				? $"Deleted the credentials for '{database}'."
+				: $"No stored credentials were found for '{database}'.";
+			EditorUtility.DisplayDialog("BugSplat", message, "OK");
+		}
+
+		[MenuItem("BugSplat/Symbol Upload/Check Credentials", false, 120)]
+		static void CheckCredentials()
+		{
+			var database = BuildPostprocessors.GetBugSplatOptions()?.Database;
+			if (string.IsNullOrEmpty(database))
+			{
+				EditorUtility.DisplayDialog("BugSplat", "No BugSplatOptions asset with a database was found in this project.", "OK");
+				return;
+			}
+
+			var resolved = BugSplatSymbolUploadCredentials.TryResolve(database, out _, out _);
+			var source = System.Environment.GetEnvironmentVariable(BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable) != null
+				? "the environment"
+				: BugSplatSymbolUploadCredentials.GetCredentialsPath(database);
+
+			EditorUtility.DisplayDialog(
+				"BugSplat",
+				resolved
+					? $"Symbol upload credentials for '{database}' resolve from {source}."
+					: $"No symbol upload credentials found for '{database}'.\n\nSet {BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and {BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use BugSplat > Symbol Upload > Set Credentials.",
+				"OK");
+		}
+
+		void OnGUI()
+		{
+			EditorGUILayout.HelpBox(
+				"Credentials are stored per database in your home directory, outside this project — " +
+				"never in the project or in a build. Generate them on BugSplat's Integrations page.",
+				MessageType.Info);
+
+			EditorGUILayout.Space();
+			database = EditorGUILayout.TextField("Database", database);
+			clientId = EditorGUILayout.TextField("Client ID", clientId);
+			clientSecret = EditorGUILayout.PasswordField("Client Secret", clientSecret);
+
+			EditorGUILayout.Space();
+			if (!string.IsNullOrWhiteSpace(database))
+			{
+				EditorGUILayout.LabelField("Saves to", BugSplatSymbolUploadCredentials.GetCredentialsPath(database), EditorStyles.wordWrappedMiniLabel);
+			}
+
+			GUILayout.FlexibleSpace();
+
+			using (new EditorGUI.DisabledScope(
+				string.IsNullOrWhiteSpace(database) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret)))
+			{
+				if (GUILayout.Button("Save"))
+				{
+					BugSplatSymbolUploadCredentials.Write(database.Trim(), clientId.Trim(), clientSecret.Trim());
+					Debug.Log($"BugSplat: saved symbol upload credentials for '{database.Trim()}' to {BugSplatSymbolUploadCredentials.GetCredentialsPath(database.Trim())}");
+					Close();
+				}
+			}
+		}
+	}
+}

--- a/Editor/BugSplatSymbolUploadMenu.cs
+++ b/Editor/BugSplatSymbolUploadMenu.cs
@@ -61,17 +61,39 @@ namespace BugSplatUnity.Editor
 				return;
 			}
 
-			var resolved = BugSplatSymbolUploadCredentials.TryResolve(database, out _, out _);
-			var source = System.Environment.GetEnvironmentVariable(BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable) != null
-				? "the environment"
-				: BugSplatSymbolUploadCredentials.GetCredentialsPath(database);
+			if (!BugSplatSymbolUploadCredentials.TryResolve(database, out _, out _))
+			{
+				EditorUtility.DisplayDialog(
+					"BugSplat",
+					$"No symbol upload credentials found for '{database}'.\n\nSet {BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and {BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use BugSplat > Symbol Upload > Set Credentials.",
+					"OK");
+				return;
+			}
 
-			EditorUtility.DisplayDialog(
-				"BugSplat",
-				resolved
-					? $"Symbol upload credentials for '{database}' resolve from {source}."
-					: $"No symbol upload credentials found for '{database}'.\n\nSet {BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and {BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use BugSplat > Symbol Upload > Set Credentials.",
-				"OK");
+			// Report what a build would actually use. The environment only supplies a value when it
+			// is non-empty, and it can supply one of the two while the file supplies the other.
+			var envHasId = !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable));
+			var envHasSecret = !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable));
+			var path = BugSplatSymbolUploadCredentials.GetCredentialsPath(database);
+
+			string source;
+			if (envHasId && envHasSecret)
+			{
+				source = "the environment";
+			}
+			else if (!envHasId && !envHasSecret)
+			{
+				source = path;
+			}
+			else
+			{
+				var fromEnvironment = envHasId
+					? BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable
+					: BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable;
+				source = $"{fromEnvironment} in the environment, and the rest from {path}";
+			}
+
+			EditorUtility.DisplayDialog("BugSplat", $"Symbol upload credentials for '{database}' resolve from {source}.", "OK");
 		}
 
 		void OnGUI()

--- a/Editor/BugSplatSymbolUploadMenu.cs.meta
+++ b/Editor/BugSplatSymbolUploadMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c0f5a91d3ab4d6f9a2e7b13c5d8e604
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -300,7 +300,7 @@ public class BuildPostprocessors
 		project.AddBuildProperty(mainTargetGuid, "ENABLE_BITCODE", "NO");
 		project.SetBuildProperty(mainTargetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
 
-		HandleUploadSymbols(mainTargetGuid, project, options, pathToBuiltProject);
+		HandleUploadSymbols(mainTargetGuid, project, options);
 
 		File.WriteAllText(projectPath, project.WriteToString());
 
@@ -354,7 +354,7 @@ public class BuildPostprocessors
 		}
 	}
 
-	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options, string pathToBuiltProject)
+	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options)
 	{
 		if (!options.UploadDebugSymbolsForIos)
 			return;
@@ -418,8 +418,34 @@ public class BuildPostprocessors
 			$"        --directory \"${{PROJECT_DIR}}\"\n" +
 			$"fi";
 
-		if (string.IsNullOrEmpty(project.GetShellScriptBuildPhaseForTarget(targetGuid, name, shellPath, shellScript)))
-			project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
+		if (!string.IsNullOrEmpty(project.GetShellScriptBuildPhaseForTarget(targetGuid, name, shellPath, shellScript)))
+			return;
+
+		// GetShellScriptBuildPhaseForTarget matches on name, shellPath *and* script body, so a phase
+		// written by an older version does not match this one. Inserting regardless would leave two
+		// phases, with the older one still uploading - and, before this change, still carrying
+		// credentials inlined into project.pbxproj.
+		if (HasBuildPhaseNamed(project, targetGuid, name))
+		{
+			Debug.LogWarning(
+				$"BugSplat: the Xcode project already has a '{name}' build phase from an earlier version, so a new one was not added. " +
+				"Delete that phase and build again, or export with Replace instead of Append. " +
+				"If it was generated before 5.0.0 it contains your symbol upload Client ID and Secret in plain text - rotate them.");
+			return;
+		}
+
+		project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
+	}
+
+	private static bool HasBuildPhaseNamed(PBXProject project, string targetGuid, string name)
+	{
+		foreach (var phaseGuid in project.GetAllBuildPhasesForTarget(targetGuid))
+		{
+			if (string.Equals(project.GetBuildPhaseName(phaseGuid), name))
+				return true;
+		}
+
+		return false;
 	}
 
 #endif

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -354,38 +354,37 @@ public class BuildPostprocessors
 		}
 	}
 
-	const string IosCredentialsFileName = "bugsplat-credentials.sh";
-
 	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options, string pathToBuiltProject)
 	{
 		if (!options.UploadDebugSymbolsForIos)
 			return;
 
-		var clientId = BugSplatSymbolUploadCredentials.GetClientId(options);
-		var clientSecret = BugSplatSymbolUploadCredentials.GetClientSecret(options);
-
-		if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+		if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out _, out _))
 		{
-			Debug.LogWarning($"BugSplat: SymbolUploadClientId/Secret not set. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET in the Xcode build environment or create {IosCredentialsFileName} next to the Xcode project, otherwise the dSYM upload build phase will skip uploading.");
-		}
-		else if (!BugSplatSymbolUploadCredentials.EnvironmentHasCredentials)
-		{
-			WriteIosCredentialsFile(pathToBuiltProject, clientId, clientSecret);
+			Debug.LogWarning(
+				$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
+				$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
+				$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable} in the Xcode build environment, or use " +
+				"BugSplat > Symbol Upload > Set Credentials. The dSYM upload build phase will skip uploading without them.");
 		}
 
 		var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
 		var version = string.IsNullOrEmpty(options.Version) ? Application.version : options.Version;
 
+		// Resolved against $HOME at Xcode build time, so the credentials never enter the project
+		// and the generated script carries no path from the machine that ran the Unity build.
+		var credentialsRelativePath = BugSplatSymbolUploadCredentials.GetCredentialsPathRelativeToHome(options.Database);
+
 		const string shellPath = "/bin/sh";
 		const int index = 999;
 		const string name = "Upload dSYM files to BugSplat";
 		var shellScript =
-			$"BUGSPLAT_CREDENTIALS=\"${{PROJECT_DIR}}/{IosCredentialsFileName}\"\n" +
+			$"BUGSPLAT_CREDENTIALS=\"$HOME/{credentialsRelativePath}\"\n" +
 			$"if [ -f \"$BUGSPLAT_CREDENTIALS\" ]; then\n" +
 			$"    . \"$BUGSPLAT_CREDENTIALS\"\n" +
 			$"fi\n" +
 			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] || [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ]; then\n" +
-			$"    echo \"warning: BugSplat symbol upload credentials not found. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET or create {IosCredentialsFileName} next to the Xcode project. Skipping dSYM upload.\"\n" +
+			$"    echo \"warning: BugSplat symbol upload credentials not found. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or run BugSplat > Symbol Upload > Set Credentials in Unity. Skipping dSYM upload.\"\n" +
 			$"    exit 0\n" +
 			$"fi\n" +
 			$"export SYMBOL_UPLOAD_CLIENT_ID SYMBOL_UPLOAD_CLIENT_SECRET\n\n" +
@@ -423,41 +422,6 @@ public class BuildPostprocessors
 			project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
 	}
 
-	private static void WriteIosCredentialsFile(string pathToBuiltProject, string clientId, string clientSecret)
-	{
-		var credentialsPath = Path.Combine(pathToBuiltProject, IosCredentialsFileName);
-		File.WriteAllText(credentialsPath,
-			$"export SYMBOL_UPLOAD_CLIENT_ID='{EscapeShellSingleQuoted(clientId)}'\n" +
-			$"export SYMBOL_UPLOAD_CLIENT_SECRET='{EscapeShellSingleQuoted(clientSecret)}'\n");
-
-		AddToGitIgnore(pathToBuiltProject, IosCredentialsFileName);
-
-		Debug.Log($"BugSplat: Wrote symbol upload credentials to {IosCredentialsFileName} next to the Xcode project and added it to .gitignore. Do not commit this file.");
-	}
-
-	private static string EscapeShellSingleQuoted(string value)
-	{
-		return value.Replace("'", "'\\''");
-	}
-
-	private static void AddToGitIgnore(string directory, string entry)
-	{
-		var gitIgnorePath = Path.Combine(directory, ".gitignore");
-
-		if (!File.Exists(gitIgnorePath))
-		{
-			File.WriteAllText(gitIgnorePath, $"{entry}\n");
-			return;
-		}
-
-		foreach (var line in File.ReadAllLines(gitIgnorePath))
-		{
-			if (string.Equals(line.Trim(), entry))
-				return;
-		}
-
-		File.AppendAllText(gitIgnorePath, $"\n{entry}\n");
-	}
 #endif
 
 #if UNITY_ANDROID
@@ -541,18 +505,13 @@ public class BuildPostprocessors
 
 	private static void UploadSymbols(string artifactsDirPath, string globPattern, BugSplatOptions options, Action<int> onCompleted)
 	{
-		string clientId = BugSplatSymbolUploadCredentials.GetClientId(options);
-		if (string.IsNullOrEmpty(clientId))
+		if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out var clientId, out var clientSecret))
 		{
-			Debug.LogWarning("BugSplat: SymbolUploadClientId is not set in BugSplatOptions or in the environment variable SYMBOL_UPLOAD_CLIENT_ID. Skipping symbol uploads.");
-			onCompleted(0);
-			return;
-		}
-
-		string clientSecret = BugSplatSymbolUploadCredentials.GetClientSecret(options);
-		if (string.IsNullOrEmpty(clientSecret))
-		{
-			Debug.LogWarning("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions or in the environment variable SYMBOL_UPLOAD_CLIENT_SECRET. Skipping symbol uploads");
+			Debug.LogWarning(
+				$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
+				$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
+				$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use " +
+				"BugSplat > Symbol Upload > Set Credentials. Skipping symbol uploads.");
 			onCompleted(0);
 			return;
 		}

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -267,7 +267,7 @@ public class BuildPostprocessors
 		});
 	}
 
-	private static BugSplatOptions GetBugSplatOptions()
+	internal static BugSplatOptions GetBugSplatOptions()
 	{
 		var guids = AssetDatabase.FindAssets("t:BugSplatOptions");
 
@@ -300,7 +300,7 @@ public class BuildPostprocessors
 		project.AddBuildProperty(mainTargetGuid, "ENABLE_BITCODE", "NO");
 		project.SetBuildProperty(mainTargetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
 
-		HandleUploadSymbols(mainTargetGuid, project, options);
+		HandleUploadSymbols(mainTargetGuid, project, options, pathToBuiltProject);
 
 		File.WriteAllText(projectPath, project.WriteToString());
 
@@ -354,23 +354,23 @@ public class BuildPostprocessors
 		}
 	}
 
-	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options)
+	const string IosCredentialsFileName = "bugsplat-credentials.sh";
+
+	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options, string pathToBuiltProject)
 	{
 		if (!options.UploadDebugSymbolsForIos)
 			return;
 
-		string clientId = Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_ID");
-		if (string.IsNullOrEmpty(clientId))
-			clientId = options.SymbolUploadClientId;
-
-		string clientSecret = Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_SECRET");
-		if (string.IsNullOrEmpty(clientSecret))
-			clientSecret = options.SymbolUploadClientSecret;
+		var clientId = BugSplatSymbolUploadCredentials.GetClientId(options);
+		var clientSecret = BugSplatSymbolUploadCredentials.GetClientSecret(options);
 
 		if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
 		{
-			Debug.LogWarning("BugSplat: SymbolUploadClientId/Secret not set. Skipping iOS dSYM upload build phase.");
-			return;
+			Debug.LogWarning($"BugSplat: SymbolUploadClientId/Secret not set. Set BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET in the Xcode build environment or create {IosCredentialsFileName} next to the Xcode project, otherwise the dSYM upload build phase will skip uploading.");
+		}
+		else if (!BugSplatSymbolUploadCredentials.EnvironmentHasCredentials)
+		{
+			WriteIosCredentialsFile(pathToBuiltProject, clientId, clientSecret);
 		}
 
 		var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
@@ -380,6 +380,21 @@ public class BuildPostprocessors
 		const int index = 999;
 		const string name = "Upload dSYM files to BugSplat";
 		var shellScript =
+			$"BUGSPLAT_CREDENTIALS=\"${{PROJECT_DIR}}/{IosCredentialsFileName}\"\n" +
+			$"if [ -f \"$BUGSPLAT_CREDENTIALS\" ]; then\n" +
+			$"    . \"$BUGSPLAT_CREDENTIALS\"\n" +
+			$"fi\n" +
+			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] && [ -n \"$BUGSPLAT_CLIENT_ID\" ]; then\n" +
+			$"    SYMBOL_UPLOAD_CLIENT_ID=\"$BUGSPLAT_CLIENT_ID\"\n" +
+			$"fi\n" +
+			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ] && [ -n \"$BUGSPLAT_CLIENT_SECRET\" ]; then\n" +
+			$"    SYMBOL_UPLOAD_CLIENT_SECRET=\"$BUGSPLAT_CLIENT_SECRET\"\n" +
+			$"fi\n" +
+			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] || [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ]; then\n" +
+			$"    echo \"warning: BugSplat symbol upload credentials not found. Set BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET or create {IosCredentialsFileName} next to the Xcode project. Skipping dSYM upload.\"\n" +
+			$"    exit 0\n" +
+			$"fi\n" +
+			$"export SYMBOL_UPLOAD_CLIENT_ID SYMBOL_UPLOAD_CLIENT_SECRET\n\n" +
 			$"if [ \"$(uname -m)\" = \"x86_64\" ]; then\n" +
 			$"    VARIANT=\"symbol-upload-macos-intel\"\n" +
 			$"else\n" +
@@ -395,8 +410,6 @@ public class BuildPostprocessors
 			$"    --database \"{options.Database}\" \\\n" +
 			$"    --application \"{application}\" \\\n" +
 			$"    --version \"{version}\" \\\n" +
-			$"    --clientId \"{clientId}\" \\\n" +
-			$"    --clientSecret \"{clientSecret}\" \\\n" +
 			$"    --files \"**/*.dSYM\" \\\n" +
 			$"    --directory \"${{BUILT_PRODUCTS_DIR}}\"\n\n" +
 			$"# Upload LineNumberMappings.json for IL2CPP C# symbolication.\n" +
@@ -408,14 +421,48 @@ public class BuildPostprocessors
 			$"        --database \"{options.Database}\" \\\n" +
 			$"        --application \"{application}\" \\\n" +
 			$"        --version \"{version}\" \\\n" +
-			$"        --clientId \"{clientId}\" \\\n" +
-			$"        --clientSecret \"{clientSecret}\" \\\n" +
 			$"        --files \"LineNumberMappings.json.zip\" \\\n" +
 			$"        --directory \"${{PROJECT_DIR}}\"\n" +
 			$"fi";
 
 		if (string.IsNullOrEmpty(project.GetShellScriptBuildPhaseForTarget(targetGuid, name, shellPath, shellScript)))
 			project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
+	}
+
+	private static void WriteIosCredentialsFile(string pathToBuiltProject, string clientId, string clientSecret)
+	{
+		var credentialsPath = Path.Combine(pathToBuiltProject, IosCredentialsFileName);
+		File.WriteAllText(credentialsPath,
+			$"export SYMBOL_UPLOAD_CLIENT_ID='{EscapeShellSingleQuoted(clientId)}'\n" +
+			$"export SYMBOL_UPLOAD_CLIENT_SECRET='{EscapeShellSingleQuoted(clientSecret)}'\n");
+
+		AddToGitIgnore(pathToBuiltProject, IosCredentialsFileName);
+
+		Debug.Log($"BugSplat: Wrote symbol upload credentials to {IosCredentialsFileName} next to the Xcode project and added it to .gitignore. Do not commit this file.");
+	}
+
+	private static string EscapeShellSingleQuoted(string value)
+	{
+		return value.Replace("'", "'\\''");
+	}
+
+	private static void AddToGitIgnore(string directory, string entry)
+	{
+		var gitIgnorePath = Path.Combine(directory, ".gitignore");
+
+		if (!File.Exists(gitIgnorePath))
+		{
+			File.WriteAllText(gitIgnorePath, $"{entry}\n");
+			return;
+		}
+
+		foreach (var line in File.ReadAllLines(gitIgnorePath))
+		{
+			if (string.Equals(line.Trim(), entry))
+				return;
+		}
+
+		File.AppendAllText(gitIgnorePath, $"\n{entry}\n");
 	}
 #endif
 
@@ -500,12 +547,7 @@ public class BuildPostprocessors
 
 	private static void UploadSymbols(string artifactsDirPath, string globPattern, BugSplatOptions options, Action<int> onCompleted)
 	{
-		string clientId = Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_ID");
-		if (string.IsNullOrEmpty(clientId))
-		{
-			clientId = options.SymbolUploadClientId;
-		}
-		
+		string clientId = BugSplatSymbolUploadCredentials.GetClientId(options);
 		if (string.IsNullOrEmpty(clientId))
 		{
 			Debug.LogWarning("BugSplat: SymbolUploadClientId is not set in BugSplatOptions or in the environment variable BUGSPLAT_CLIENT_ID. Skipping symbol uploads.");
@@ -513,12 +555,7 @@ public class BuildPostprocessors
 			return;
 		}
 
-		string clientSecret = Environment.GetEnvironmentVariable("BUGSPLAT_CLIENT_SECRET");
-		if (string.IsNullOrEmpty(clientSecret))
-		{
-			clientSecret = options.SymbolUploadClientSecret;
-		}
-
+		string clientSecret = BugSplatSymbolUploadCredentials.GetClientSecret(options);
 		if (string.IsNullOrEmpty(clientSecret))
 		{
 			Debug.LogWarning("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions or in the environment variable BUGSPLAT_CLIENT_SECRET. Skipping symbol uploads");
@@ -540,9 +577,12 @@ public class BuildPostprocessors
 			FileName = symbolUploadPath,
 			UseShellExecute = false,
 			RedirectStandardOutput = true,
-			Arguments = $"--database {options.Database} --application \"{application}\" --clientId {clientId} --clientSecret {clientSecret} " +
+			Arguments = $"--database {options.Database} --application \"{application}\" " +
 				$"--version \"{version}\" --files \"{globPattern}\" --directory \"{artifactsDirPath}\""
 		};
+
+		symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_ID"] = clientId;
+		symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_SECRET"] = clientSecret;
 
 		if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android)
 		{

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -366,7 +366,7 @@ public class BuildPostprocessors
 
 		if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
 		{
-			Debug.LogWarning($"BugSplat: SymbolUploadClientId/Secret not set. Set BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET in the Xcode build environment or create {IosCredentialsFileName} next to the Xcode project, otherwise the dSYM upload build phase will skip uploading.");
+			Debug.LogWarning($"BugSplat: SymbolUploadClientId/Secret not set. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET in the Xcode build environment or create {IosCredentialsFileName} next to the Xcode project, otherwise the dSYM upload build phase will skip uploading.");
 		}
 		else if (!BugSplatSymbolUploadCredentials.EnvironmentHasCredentials)
 		{
@@ -384,14 +384,8 @@ public class BuildPostprocessors
 			$"if [ -f \"$BUGSPLAT_CREDENTIALS\" ]; then\n" +
 			$"    . \"$BUGSPLAT_CREDENTIALS\"\n" +
 			$"fi\n" +
-			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] && [ -n \"$BUGSPLAT_CLIENT_ID\" ]; then\n" +
-			$"    SYMBOL_UPLOAD_CLIENT_ID=\"$BUGSPLAT_CLIENT_ID\"\n" +
-			$"fi\n" +
-			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ] && [ -n \"$BUGSPLAT_CLIENT_SECRET\" ]; then\n" +
-			$"    SYMBOL_UPLOAD_CLIENT_SECRET=\"$BUGSPLAT_CLIENT_SECRET\"\n" +
-			$"fi\n" +
 			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] || [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ]; then\n" +
-			$"    echo \"warning: BugSplat symbol upload credentials not found. Set BUGSPLAT_CLIENT_ID and BUGSPLAT_CLIENT_SECRET or create {IosCredentialsFileName} next to the Xcode project. Skipping dSYM upload.\"\n" +
+			$"    echo \"warning: BugSplat symbol upload credentials not found. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET or create {IosCredentialsFileName} next to the Xcode project. Skipping dSYM upload.\"\n" +
 			$"    exit 0\n" +
 			$"fi\n" +
 			$"export SYMBOL_UPLOAD_CLIENT_ID SYMBOL_UPLOAD_CLIENT_SECRET\n\n" +
@@ -550,7 +544,7 @@ public class BuildPostprocessors
 		string clientId = BugSplatSymbolUploadCredentials.GetClientId(options);
 		if (string.IsNullOrEmpty(clientId))
 		{
-			Debug.LogWarning("BugSplat: SymbolUploadClientId is not set in BugSplatOptions or in the environment variable BUGSPLAT_CLIENT_ID. Skipping symbol uploads.");
+			Debug.LogWarning("BugSplat: SymbolUploadClientId is not set in BugSplatOptions or in the environment variable SYMBOL_UPLOAD_CLIENT_ID. Skipping symbol uploads.");
 			onCompleted(0);
 			return;
 		}
@@ -558,7 +552,7 @@ public class BuildPostprocessors
 		string clientSecret = BugSplatSymbolUploadCredentials.GetClientSecret(options);
 		if (string.IsNullOrEmpty(clientSecret))
 		{
-			Debug.LogWarning("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions or in the environment variable BUGSPLAT_CLIENT_SECRET. Skipping symbol uploads");
+			Debug.LogWarning("BugSplat. SymbolUploadClientSecret is not set in BugSplatOptions or in the environment variable SYMBOL_UPLOAD_CLIENT_SECRET. Skipping symbol uploads");
 			onCompleted(0);
 			return;
 		}

--- a/README.md
+++ b/README.md
@@ -410,8 +410,8 @@ The following API methods are available to help you customize BugSplat to fit yo
 | PostExceptionsInEditor | Should BugSplat upload exceptions when in editor |
 | PersistentDataFileAttachmentPaths |  Paths to files (relative to Application.persistentDataPath) to upload with each report |
 | ShouldPostException | Settable guard function that is called before each BugSplat report is posted |
-| SymbolUploadClientId | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page
-| SymbolUploadClientSecret | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page
+| SymbolUploadClientId | An OAuth2 Client ID used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `BUGSPLAT_CLIENT_ID`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
+| SymbolUploadClientSecret | An OAuth2 Client Secret used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `BUGSPLAT_CLIENT_SECRET`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
 | UseNativeCrashReportingForWindows | Use native crash reporting library (bugsplat-windows) for Windows builds. Works with both Mono and IL2CPP |
 | WindowsShowCrashDialog | Show the BugSplat crash dialog when a native crash occurs on Windows (default). When disabled, crash reports are sent silently |
 | WindowsHangDetectionTimeoutMs | Native hang detection timeout in milliseconds for Windows. 0 (default) disables hang detection |
@@ -422,6 +422,20 @@ The following API methods are available to help you customize BugSplat to fit yo
 |----------| --------------- |
 | BUGSPLAT_CLIENT_ID | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientId
 | BUGSPLAT_CLIENT_SECRET | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientSecret
+| SYMBOL_UPLOAD_CLIENT_ID | Read by the `symbol-upload` CLI itself. Set this when your CI runs `xcodebuild` — Unity's generated build phase maps `BUGSPLAT_CLIENT_ID` onto it |
+| SYMBOL_UPLOAD_CLIENT_SECRET | Read by the `symbol-upload` CLI itself. Set this when your CI runs `xcodebuild` — Unity's generated build phase maps `BUGSPLAT_CLIENT_SECRET` onto it |
+
+### Symbol Upload Credentials
+
+Credentials come from BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page. They are resolved in this order:
+
+1. **`BUGSPLAT_CLIENT_ID` / `BUGSPLAT_CLIENT_SECRET` environment variables** — recommended. The secret never touches disk or version control.
+2. **`bugsplat-credentials.sh`** (iOS only) — written next to the exported Xcode project when the credentials came from the options asset, and added to that project's `.gitignore`. It holds the secret in plain text, so keep it out of version control. This is the route for Xcode GUI builds, which don't inherit your shell environment.
+3. **The `BugSplatOptions` asset** — kept for backwards compatibility. The fields are blanked while the player build serializes the asset and restored afterwards, so the secret no longer ships inside builds.
+
+For CI that builds the exported Xcode project itself, set `SYMBOL_UPLOAD_CLIENT_ID` and `SYMBOL_UPLOAD_CLIENT_SECRET` in the `xcodebuild` environment. When no credentials resolve, the build phase logs an Xcode warning and the build succeeds without uploading symbols.
+
+> **Upgrading:** if a `BugSplatOptions` asset holding credentials has ever been committed, rotate them. Prior versions serialized both values into player builds and into the generated `project.pbxproj`.
 
 ## 🧑‍💻 Contributing
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,8 @@ Version 5.0.0 replaces the Unity crash-folder minidump flow with native crash re
 - `PostAllCrashes`, `PostCrash`, and `PostMostRecentCrash` have been removed. Unsent native crash reports are uploaded automatically at startup — you no longer need to call anything at launch. Delete any calls to these methods.
 - Unity's `CrashReporting.crashReportFolder` minidumps are no longer read or uploaded.
 - `Post(FileInfo minidump)` still works on all platforms for posting your own minidump files.
-- The symbol upload environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`, matching the names the `symbol-upload` CLI already reads. Rename them wherever they are set — the old names are no longer read. See [Symbol Upload Credentials](#symbol-upload-credentials).
+- `SymbolUploadClientId` and `SymbolUploadClientSecret` have been removed from `BugSplatOptions`. Storing them there put the secret in version control and inside shipped builds. Set them per database from **BugSplat > Symbol Upload > Set Credentials**, or with environment variables in CI.
+- Those environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`, matching the names the `symbol-upload` CLI already reads. The old names are no longer read. See [Symbol Upload Credentials](#symbol-upload-credentials).
 
 ## 🧩 API
 
@@ -411,8 +412,6 @@ The following API methods are available to help you customize BugSplat to fit yo
 | PostExceptionsInEditor | Should BugSplat upload exceptions when in editor |
 | PersistentDataFileAttachmentPaths |  Paths to files (relative to Application.persistentDataPath) to upload with each report |
 | ShouldPostException | Settable guard function that is called before each BugSplat report is posted |
-| SymbolUploadClientId | An OAuth2 Client ID used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `SYMBOL_UPLOAD_CLIENT_ID`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
-| SymbolUploadClientSecret | An OAuth2 Client Secret used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `SYMBOL_UPLOAD_CLIENT_SECRET`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
 | UseNativeCrashReportingForWindows | Use native crash reporting library (bugsplat-windows) for Windows builds. Works with both Mono and IL2CPP |
 | WindowsShowCrashDialog | Show the BugSplat crash dialog when a native crash occurs on Windows (default). When disabled, crash reports are sent silently |
 | WindowsHangDetectionTimeoutMs | Native hang detection timeout in milliseconds for Windows. 0 (default) disables hang detection |
@@ -426,15 +425,16 @@ The following API methods are available to help you customize BugSplat to fit yo
 
 ### Symbol Upload Credentials
 
-Credentials come from BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page. They are resolved in this order:
+Credentials are generated on BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page and are **specific to one database**. They are never stored in your project — an asset carrying them ends up in version control and inside shipped builds. They resolve in this order:
 
-1. **`SYMBOL_UPLOAD_CLIENT_ID` / `SYMBOL_UPLOAD_CLIENT_SECRET` environment variables** — recommended. The secret never touches disk or version control. These are the names the `symbol-upload` CLI reads, so the same pair works whether Unity runs the upload or your CI runs `xcodebuild` itself.
-2. **`bugsplat-credentials.sh`** (iOS only) — written next to the exported Xcode project when the credentials came from the options asset, and added to that project's `.gitignore`. It holds the secret in plain text, so keep it out of version control. This is the route for Xcode GUI builds, which don't inherit your shell environment.
-3. **The `BugSplatOptions` asset** — kept for backwards compatibility. The fields are blanked while the player build serializes the asset and restored afterwards, so the secret no longer ships inside builds.
+1. **`SYMBOL_UPLOAD_CLIENT_ID` / `SYMBOL_UPLOAD_CLIENT_SECRET` environment variables** — use these in CI. They are the names the `symbol-upload` CLI reads, so the same pair works whether Unity runs the upload or your CI runs `xcodebuild` itself.
+2. **`~/.bugsplat/credentials/<database>.sh`** — for local development. Set it from **BugSplat > Symbol Upload > Set Credentials**, which writes one file per database, so a machine can hold credentials for as many databases as you work with.
 
-When no credentials resolve, the iOS build phase logs an Xcode warning and the build succeeds without uploading symbols.
+`Clear Credentials` deletes the current project's file; `Check Credentials` reports which source a build would use. When neither source supplies both values, symbol upload is skipped with a warning and the build still succeeds — on iOS as an Xcode build warning, since that upload runs during the Xcode build rather than the Unity one.
 
-> **Upgrading from 4.x:** the environment variables were previously named `BUGSPLAT_CLIENT_ID` and `BUGSPLAT_CLIENT_SECRET`; rename them. If a `BugSplatOptions` asset holding credentials has ever been committed, rotate them — prior versions serialized both values into player builds and into the generated `project.pbxproj`.
+Because the file lives in your home directory rather than the project, there is nothing to add to `.gitignore` and nothing to strip out of a build.
+
+> **Upgrading from 4.x:** `SymbolUploadClientId` and `SymbolUploadClientSecret` have been removed from `BugSplatOptions`, and the environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET`. Move your credentials to the menu or the new variables. **If an options asset holding credentials has ever been committed, rotate them** — prior versions serialized both values into player builds and into the generated `project.pbxproj`.
 
 ## 🧑‍💻 Contributing
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Version 5.0.0 replaces the Unity crash-folder minidump flow with native crash re
 - `PostAllCrashes`, `PostCrash`, and `PostMostRecentCrash` have been removed. Unsent native crash reports are uploaded automatically at startup — you no longer need to call anything at launch. Delete any calls to these methods.
 - Unity's `CrashReporting.crashReportFolder` minidumps are no longer read or uploaded.
 - `Post(FileInfo minidump)` still works on all platforms for posting your own minidump files.
+- The symbol upload environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`, matching the names the `symbol-upload` CLI already reads. Rename them wherever they are set — the old names are no longer read. See [Symbol Upload Credentials](#symbol-upload-credentials).
 
 ## 🧩 API
 
@@ -410,8 +411,8 @@ The following API methods are available to help you customize BugSplat to fit yo
 | PostExceptionsInEditor | Should BugSplat upload exceptions when in editor |
 | PersistentDataFileAttachmentPaths |  Paths to files (relative to Application.persistentDataPath) to upload with each report |
 | ShouldPostException | Settable guard function that is called before each BugSplat report is posted |
-| SymbolUploadClientId | An OAuth2 Client ID used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `BUGSPLAT_CLIENT_ID`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
-| SymbolUploadClientSecret | An OAuth2 Client Secret used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `BUGSPLAT_CLIENT_SECRET`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
+| SymbolUploadClientId | An OAuth2 Client ID used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `SYMBOL_UPLOAD_CLIENT_ID`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
+| SymbolUploadClientSecret | An OAuth2 Client Secret used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files). Legacy — prefer `SYMBOL_UPLOAD_CLIENT_SECRET`, see [Symbol Upload Credentials](#symbol-upload-credentials) |
 | UseNativeCrashReportingForWindows | Use native crash reporting library (bugsplat-windows) for Windows builds. Works with both Mono and IL2CPP |
 | WindowsShowCrashDialog | Show the BugSplat crash dialog when a native crash occurs on Windows (default). When disabled, crash reports are sent silently |
 | WindowsHangDetectionTimeoutMs | Native hang detection timeout in milliseconds for Windows. 0 (default) disables hang detection |
@@ -420,22 +421,20 @@ The following API methods are available to help you customize BugSplat to fit yo
 
 | Variable | Description |
 |----------| --------------- |
-| BUGSPLAT_CLIENT_ID | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientId
-| BUGSPLAT_CLIENT_SECRET | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientSecret
-| SYMBOL_UPLOAD_CLIENT_ID | Read by the `symbol-upload` CLI itself. Set this when your CI runs `xcodebuild` — Unity's generated build phase maps `BUGSPLAT_CLIENT_ID` onto it |
-| SYMBOL_UPLOAD_CLIENT_SECRET | Read by the `symbol-upload` CLI itself. Set this when your CI runs `xcodebuild` — Unity's generated build phase maps `BUGSPLAT_CLIENT_SECRET` onto it |
+| SYMBOL_UPLOAD_CLIENT_ID | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientId |
+| SYMBOL_UPLOAD_CLIENT_SECRET | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientSecret |
 
 ### Symbol Upload Credentials
 
 Credentials come from BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page. They are resolved in this order:
 
-1. **`BUGSPLAT_CLIENT_ID` / `BUGSPLAT_CLIENT_SECRET` environment variables** — recommended. The secret never touches disk or version control.
+1. **`SYMBOL_UPLOAD_CLIENT_ID` / `SYMBOL_UPLOAD_CLIENT_SECRET` environment variables** — recommended. The secret never touches disk or version control. These are the names the `symbol-upload` CLI reads, so the same pair works whether Unity runs the upload or your CI runs `xcodebuild` itself.
 2. **`bugsplat-credentials.sh`** (iOS only) — written next to the exported Xcode project when the credentials came from the options asset, and added to that project's `.gitignore`. It holds the secret in plain text, so keep it out of version control. This is the route for Xcode GUI builds, which don't inherit your shell environment.
 3. **The `BugSplatOptions` asset** — kept for backwards compatibility. The fields are blanked while the player build serializes the asset and restored afterwards, so the secret no longer ships inside builds.
 
-For CI that builds the exported Xcode project itself, set `SYMBOL_UPLOAD_CLIENT_ID` and `SYMBOL_UPLOAD_CLIENT_SECRET` in the `xcodebuild` environment. When no credentials resolve, the build phase logs an Xcode warning and the build succeeds without uploading symbols.
+When no credentials resolve, the iOS build phase logs an Xcode warning and the build succeeds without uploading symbols.
 
-> **Upgrading:** if a `BugSplatOptions` asset holding credentials has ever been committed, rotate them. Prior versions serialized both values into player builds and into the generated `project.pbxproj`.
+> **Upgrading from 4.x:** the environment variables were previously named `BUGSPLAT_CLIENT_ID` and `BUGSPLAT_CLIENT_SECRET`; rename them. If a `BugSplatOptions` asset holding credentials has ever been committed, rotate them — prior versions serialized both values into player builds and into the generated `project.pbxproj`.
 
 ## 🧑‍💻 Contributing
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ BugSplat captures native Windows crashes via [BugSplat for Windows](https://docs
 
 ### Windows Symbols
 
-To enable the uploading of plugin symbols, generate an OAuth2 Client ID and Client Secret on the BugSplat [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page. Add your Client ID and Client Secret to the `BugSplatOptions` object you generated in the [Configuration](#⚙️-configuration) section. If your game contains Native Windows C++ plugins, `.dll` and `.pdb` files in the `Assets/Plugins/x86` and `Assets/Plugins/x86_64` folders will be uploaded by BugSplat's PostBuild script and used in symbolication.
+To enable the uploading of plugin symbols, generate an OAuth2 Client ID and Client Secret on the BugSplat [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page and provide them as described in [Symbol Upload Credentials](#symbol-upload-credentials). If your game contains Native Windows C++ plugins, `.dll` and `.pdb` files in the `Assets/Plugins/x86` and `Assets/Plugins/x86_64` folders will be uploaded by BugSplat's PostBuild script and used in symbolication.
 
 For IL2CPP builds, BugSplat will also upload `LineNumberMappings.json`. Line mappings allow BugSplat to replace generated C++ function names, file names, and line numbers with their original C# equivalents.
 
@@ -382,6 +382,7 @@ Version 5.0.0 replaces the Unity crash-folder minidump flow with native crash re
 - `Post(FileInfo minidump)` still works on all platforms for posting your own minidump files.
 - `SymbolUploadClientId` and `SymbolUploadClientSecret` have been removed from `BugSplatOptions`. Storing them there put the secret in version control and inside shipped builds. Set them per database from **BugSplat > Symbol Upload > Set Credentials**, or with environment variables in CI.
 - Those environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`, matching the names the `symbol-upload` CLI already reads. The old names are no longer read. See [Symbol Upload Credentials](#symbol-upload-credentials).
+- **iOS projects exported with Append, or checked into version control, keep their old "Upload dSYM files to BugSplat" build phase.** Unity matches an existing phase on its script body, so the rewritten phase is not recognised as the same one. Delete the old phase and build again, or re-export with Replace. A phase generated before 5.0.0 contains your Client ID and Secret in plain text — **rotate them**.
 
 ## 🧩 API
 
@@ -420,8 +421,8 @@ The following API methods are available to help you customize BugSplat to fit yo
 
 | Variable | Description |
 |----------| --------------- |
-| SYMBOL_UPLOAD_CLIENT_ID | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientId |
-| SYMBOL_UPLOAD_CLIENT_SECRET | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>If set it will be used instead of options.SymbolUploadClientSecret |
+| SYMBOL_UPLOAD_CLIENT_ID | An OAuth2 Client ID value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>Takes precedence over `~/.bugsplat/credentials/<database>.sh` — see [Symbol Upload Credentials](#symbol-upload-credentials) |
+| SYMBOL_UPLOAD_CLIENT_SECRET | An OAuth2 Client Secret value used for uploading [symbol files](https://docs.bugsplat.com/introduction/development/working-with-symbol-files) generated via BugSplat's [Integrations](https://app.bugsplat.com/v2/settings/database/integrations) page.<br>Takes precedence over `~/.bugsplat/credentials/<database>.sh` — see [Symbol Upload Credentials](#symbol-upload-credentials) |
 
 ### Symbol Upload Credentials
 

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -66,18 +66,18 @@ namespace BugSplatUnity.Runtime.Client
 		
 		/// <summary>
 		/// OAuth2 Client ID generated on BugSplat's Integrations page, used to upload symbol files.
-		/// Prefer the BUGSPLAT_CLIENT_ID environment variable, which overrides this value and keeps
+		/// Prefer the SYMBOL_UPLOAD_CLIENT_ID environment variable, which overrides this value and keeps
 		/// the credential out of the asset, version control, and builds.
 		/// </summary>
-		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page. Prefer the BUGSPLAT_CLIENT_ID environment variable, which overrides this value.")]
+		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page. Prefer the SYMBOL_UPLOAD_CLIENT_ID environment variable, which overrides this value.")]
 		public string SymbolUploadClientId;
 
 		/// <summary>
 		/// OAuth2 Client Secret generated on BugSplat's Integrations page, used to upload symbol files.
-		/// Prefer the BUGSPLAT_CLIENT_SECRET environment variable, which overrides this value and keeps
+		/// Prefer the SYMBOL_UPLOAD_CLIENT_SECRET environment variable, which overrides this value and keeps
 		/// the credential out of the asset, version control, and builds.
 		/// </summary>
-		[Tooltip("OAuth2 Client Secret generated on BugSplat's Integrations page. Prefer the BUGSPLAT_CLIENT_SECRET environment variable, which overrides this value.")]
+		[Tooltip("OAuth2 Client Secret generated on BugSplat's Integrations page. Prefer the SYMBOL_UPLOAD_CLIENT_SECRET environment variable, which overrides this value.")]
 		public string SymbolUploadClientSecret;
 		
 		[Tooltip("Use crash reporting framework for iOS builds. If set to false, will only use .NET handler.")]

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -64,22 +64,6 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Attributes to attach to reports")]
 		public List<BugSplatAttribute> Attributes = new List<BugSplatAttribute>();
 		
-		/// <summary>
-		/// OAuth2 Client ID generated on BugSplat's Integrations page, used to upload symbol files.
-		/// Prefer the SYMBOL_UPLOAD_CLIENT_ID environment variable, which overrides this value and keeps
-		/// the credential out of the asset, version control, and builds.
-		/// </summary>
-		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page. Prefer the SYMBOL_UPLOAD_CLIENT_ID environment variable, which overrides this value.")]
-		public string SymbolUploadClientId;
-
-		/// <summary>
-		/// OAuth2 Client Secret generated on BugSplat's Integrations page, used to upload symbol files.
-		/// Prefer the SYMBOL_UPLOAD_CLIENT_SECRET environment variable, which overrides this value and keeps
-		/// the credential out of the asset, version control, and builds.
-		/// </summary>
-		[Tooltip("OAuth2 Client Secret generated on BugSplat's Integrations page. Prefer the SYMBOL_UPLOAD_CLIENT_SECRET environment variable, which overrides this value.")]
-		public string SymbolUploadClientSecret;
-		
 		[Tooltip("Use crash reporting framework for iOS builds. If set to false, will only use .NET handler.")]
 		public bool UseNativeCrashReportingForIos;
 

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -64,10 +64,20 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Attributes to attach to reports")]
 		public List<BugSplatAttribute> Attributes = new List<BugSplatAttribute>();
 		
-		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page")]
+		/// <summary>
+		/// OAuth2 Client ID generated on BugSplat's Integrations page, used to upload symbol files.
+		/// Prefer the BUGSPLAT_CLIENT_ID environment variable, which overrides this value and keeps
+		/// the credential out of the asset, version control, and builds.
+		/// </summary>
+		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page. Prefer the BUGSPLAT_CLIENT_ID environment variable, which overrides this value.")]
 		public string SymbolUploadClientId;
 
-		[Tooltip("OAuth2 Client Secret generated on BugSplat's Integrations page")]
+		/// <summary>
+		/// OAuth2 Client Secret generated on BugSplat's Integrations page, used to upload symbol files.
+		/// Prefer the BUGSPLAT_CLIENT_SECRET environment variable, which overrides this value and keeps
+		/// the credential out of the asset, version control, and builds.
+		/// </summary>
+		[Tooltip("OAuth2 Client Secret generated on BugSplat's Integrations page. Prefer the BUGSPLAT_CLIENT_SECRET environment variable, which overrides this value.")]
 		public string SymbolUploadClientSecret;
 		
 		[Tooltip("Use crash reporting framework for iOS builds. If set to false, will only use .NET handler.")]


### PR DESCRIPTION
> **Stacks on #123** — based on `feat/windows-native-crash-reporting` and targets it.

Fixes symbol-upload OAuth credential leaks C1–C3 from the 5.0.0 audit (#132) by removing the thing that leaked, rather than defending it.

## ⚠️ Breaking changes

**`SymbolUploadClientId` and `SymbolUploadClientSecret` are removed from `BugSplatOptions`.** Storing credentials on a ScriptableObject is what put them in version control and inside shipped player builds (C2).

**The environment variables are renamed** from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to **`SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`**. The old names are no longer read, so CI setting them must be updated or symbol uploads stop silently. These are the names the `symbol-upload` CLI already reads, which removes a mapping layer that previously existed only to translate one into the other.

> **Carry both into #123's body before it merges.** #123 is the PR that reaches `main`, so its description is what a 5.0.0 reader sees. It also needs a `Closes` reference for C1–C3 once that finding is sliced out of #132, the way A1–A5/F2/J1 were.

## Where credentials live now

A client ID and secret are issued **per database**, and a developer may work across several, so they are stored one file per database in the user's home directory:

```
~/.bugsplat/credentials/<database>.sh
```

Set from **BugSplat > Symbol Upload > Set Credentials**, mirroring the WER handler menu added in #123 — both are machine-local developer setup rather than project configuration, so both belong outside the project and behind a menu.

The file uses the shell format the CLI already reads, so the generated Xcode build phase sources it straight from `$HOME`:

```sh
BUGSPLAT_CREDENTIALS="$HOME/.bugsplat/credentials/<database>.sh"
if [ -f "$BUGSPLAT_CREDENTIALS" ]; then . "$BUGSPLAT_CREDENTIALS"; fi
```

Resolution is **environment first, then the file**. CI sets the variables; humans run the menu once.

## What this deletes

Because nothing project-local holds a secret any more:

- The `IPreprocessBuildWithReport`/`IPostprocessBuildWithReport` pair that blanked the asset fields before a build serialized them and restored them afterwards — along with the `SessionState` cache and **four** separate restore paths (post-build callback, editor update tick, domain reload, `EditorApplication.quitting`) that existed because `OnPostprocessBuild` isn't guaranteed to run when a build throws.
- Writing `bugsplat-credentials.sh` next to each exported Xcode project, and the `.gitignore` management that came with it. Gitignore is a promise; being outside the repository is a guarantee — and C2 *was* a committed asset.
- The password-masking and warning HelpBox on the options inspector, replaced by a line saying where credentials actually go.
- The `BUGSPLAT_*` → `SYMBOL_UPLOAD_*` shell mapping block in the build phase.

C3's fix stands unchanged: credentials reach the uploader through `ProcessStartInfo.EnvironmentVariables`, never as command-line arguments.

## Behaviour when credentials are missing

Uploads are skipped and the build still succeeds — a Unity warning naming the database and both routes, and on iOS an Xcode build warning, since that upload runs during the Xcode build rather than the Unity one.

## Verification

Unity 6000.5.6f1, `StandaloneWindows64`: clean compile, **59/59 tests pass**.

Not verified locally: the `#if UNITY_IOS` block in `Editor/PostBuild.cs`, since this machine has no iOS module installed. CI's iOS compile job covers it — Unity compiles Editor assemblies on project open, so a break there fails that job.

## Docs

README gains a **Symbol Upload Credentials** section covering both routes and the multi-database layout, the removed fields are dropped from the options table, and **Migrating from 4.x** records both breaking changes plus a note to **rotate any credentials that have been committed on an options asset** — prior versions serialized them into player builds and into `project.pbxproj`.
