### PR TITLE
fix: make the test suite compile and add a CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,12 @@ jobs:
       - id: tests
         uses: game-ci/unity-test-runner@v4
         env:
+          # Personal licenses use UNITY_LICENSE; Pro/Plus use the email/password/serial trio.
+          # Set whichever pair applies — GameCI activates based on which are present.
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         with:
           projectPath: TestProject
           customImage: unityci/editor:ubuntu-${{ env.UNITY_VERSION }}-${{ matrix.image }}-3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             image: webgl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: package
           lfs: true
@@ -70,7 +70,7 @@ jobs:
           }
           EOF
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: TestProject/Library
           key: Library-${{ matrix.buildTarget }}-${{ hashFiles('package/**/*.cs', 'package/**/*.asmdef') }}
@@ -107,7 +107,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-${{ matrix.buildTarget }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,18 @@ env:
   # Must be a version GameCI publishes an image for: https://hub.docker.com/r/unityci/editor/tags
   UNITY_VERSION: 6000.0.81f1
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: ${{ matrix.buildTarget }}
     runs-on: ubuntu-latest
+    # Secrets aren't exposed to forks, so the license would be empty and the run would always
+    # fail. Skip rather than report a red check a contributor can't fix.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 45
     permissions:
       checks: write
       contents: read
@@ -82,4 +90,4 @@ jobs:
         if: always()
         with:
           name: test-results-${{ matrix.buildTarget }}
-          path: ${{ steps.tests.outputs.artifactsPath }}
+          path: ${{ matrix.buildTarget }}-results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ env:
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancelling mid-run can skip GameCI's license return step and leak a Pro activation, which
+  # accumulates silently until the seat is exhausted. Superseded runs are cheaper than that.
+  cancel-in-progress: false
 
 jobs:
   tests:
@@ -27,6 +29,9 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # Each job activates the Unity serial, and a Pro seat allows only a couple of concurrent
+      # activations. Serialised so one run needs one activation. Raise once seat headroom is known.
+      max-parallel: 1
       matrix:
         include:
           - buildTarget: StandaloneLinux64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,3 +116,124 @@ jobs:
         with:
           name: test-results-${{ matrix.buildTarget }}
           path: ${{ matrix.buildTarget }}-results
+
+  # Tests run inside the editor, so everything behind `&& !UNITY_EDITOR` — every native crash
+  # path — is excluded from the assemblies they link against. Compiling the player scripts is
+  # the only thing in CI that builds that code.
+  compile:
+    name: Compile ${{ matrix.targetPlatform }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Serialised behind the tests: one Unity activation is available at a time.
+    needs: tests
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - targetPlatform: iOS
+            image: ios
+          - targetPlatform: Android
+            image: android
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: package
+          lfs: true
+
+      - name: Generate compile project
+        run: |
+          mkdir -p CompileProject/Assets/Editor CompileProject/Packages CompileProject/ProjectSettings
+          echo "m_EditorVersion: ${UNITY_VERSION}" > CompileProject/ProjectSettings/ProjectVersion.txt
+          cat > CompileProject/Packages/manifest.json <<'EOF'
+          {
+            "dependencies": {
+              "com.bugsplat.unity": "file:../../package",
+              "com.unity.modules.androidjni": "1.0.0",
+              "com.unity.modules.imageconversion": "1.0.0",
+              "com.unity.modules.imgui": "1.0.0",
+              "com.unity.modules.jsonserialize": "1.0.0",
+              "com.unity.modules.screencapture": "1.0.0",
+              "com.unity.modules.uielements": "1.0.0",
+              "com.unity.modules.unitywebrequest": "1.0.0"
+            }
+          }
+          EOF
+          cat > CompileProject/Assets/Editor/CompileCheck.cs <<'EOF'
+          using System.Linq;
+          using UnityEditor;
+          using UnityEditor.Build.Player;
+          using UnityEngine;
+
+          public static class CompileCheck
+          {
+              const string ExpectedAssembly = "BugSplat.Unity.Runtime.dll";
+
+              public static void Run()
+              {
+                  var target = EditorUserBuildSettings.activeBuildTarget;
+                  var settings = new ScriptCompilationSettings
+                  {
+                      group = BuildPipeline.GetBuildTargetGroup(target),
+                      target = target,
+                      options = ScriptCompilationOptions.None
+                  };
+
+                  ScriptCompilationResult result;
+                  try
+                  {
+                      result = PlayerBuildInterface.CompilePlayerScripts(settings, "Temp/PlayerScriptCompile");
+                  }
+                  catch (System.Exception ex)
+                  {
+                      Debug.LogError($"CompileCheck: compilation threw for {target}: {ex}");
+                      EditorApplication.Exit(1);
+                      return;
+                  }
+
+                  var assemblies = result.assemblies?.ToList();
+                  if (assemblies == null || !assemblies.Any(a => a.EndsWith(ExpectedAssembly)))
+                  {
+                      Debug.LogError($"CompileCheck: {ExpectedAssembly} was not produced for {target}");
+                      EditorApplication.Exit(1);
+                      return;
+                  }
+
+                  Debug.Log($"CompileCheck: {target} OK, {assemblies.Count} assemblies");
+                  EditorApplication.Exit(0);
+              }
+          }
+          EOF
+
+      - uses: actions/cache@v6
+        with:
+          path: CompileProject/Library
+          key: Library-compile-${{ matrix.targetPlatform }}-${{ hashFiles('package/**/*.cs', 'package/**/*.asmdef') }}
+          restore-keys: |
+            Library-compile-${{ matrix.targetPlatform }}-
+
+      - uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          projectPath: CompileProject
+          targetPlatform: ${{ matrix.targetPlatform }}
+          customImage: unityci/editor:ubuntu-${{ env.UNITY_VERSION }}-${{ matrix.image }}-3
+          buildMethod: CompileCheck.Run
+          manualExit: true
+          versioning: None
+
+      - uses: game-ci/unity-return-license@v2
+        if: always()
+        continue-on-error: true
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,85 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # Must be a version GameCI publishes an image for: https://hub.docker.com/r/unityci/editor/tags
+  UNITY_VERSION: 6000.0.81f1
+
+jobs:
+  tests:
+    name: ${{ matrix.buildTarget }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - buildTarget: StandaloneLinux64
+            image: linux-il2cpp
+          - buildTarget: WebGL
+            image: webgl
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: package
+          lfs: true
+
+      # This repo is a UPM package, not a Unity project, so the test runner needs a host
+      # project that embeds it and lists it under "testables".
+      - name: Generate test project
+        run: |
+          mkdir -p TestProject/Assets TestProject/Packages TestProject/ProjectSettings
+          echo "m_EditorVersion: ${UNITY_VERSION}" > TestProject/ProjectSettings/ProjectVersion.txt
+          cat > TestProject/Packages/manifest.json <<'EOF'
+          {
+            "dependencies": {
+              "com.bugsplat.unity": "file:../../package",
+              "com.unity.test-framework": "1.7.0",
+              "com.unity.modules.androidjni": "1.0.0",
+              "com.unity.modules.imageconversion": "1.0.0",
+              "com.unity.modules.imgui": "1.0.0",
+              "com.unity.modules.jsonserialize": "1.0.0",
+              "com.unity.modules.screencapture": "1.0.0",
+              "com.unity.modules.uielements": "1.0.0",
+              "com.unity.modules.unitywebrequest": "1.0.0"
+            },
+            "testables": [
+              "com.bugsplat.unity"
+            ]
+          }
+          EOF
+
+      - uses: actions/cache@v4
+        with:
+          path: TestProject/Library
+          key: Library-${{ matrix.buildTarget }}-${{ hashFiles('package/**/*.cs', 'package/**/*.asmdef') }}
+          restore-keys: |
+            Library-${{ matrix.buildTarget }}-
+
+      - id: tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: TestProject
+          customImage: unityci/editor:ubuntu-${{ env.UNITY_VERSION }}-${{ matrix.image }}-3
+          # The suite lives in Tests/Runtime, which the test framework treats as play mode.
+          testMode: all
+          customParameters: -buildTarget ${{ matrix.buildTarget }}
+          artifactsPath: ${{ matrix.buildTarget }}-results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: ${{ matrix.buildTarget }} test results
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.buildTarget }}
+          path: ${{ steps.tests.outputs.artifactsPath }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
         include:
           - buildTarget: StandaloneLinux64
             image: linux-il2cpp
+          - buildTarget: StandaloneWindows64
+            image: windows-mono
+          - buildTarget: StandaloneOSX
+            image: mac-mono
           - buildTarget: WebGL
             image: webgl
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,17 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.buildTarget }} test results
 
+      # Every container is a new machine to Unity, so each run consumes an activation. If a run
+      # dies before returning it, that slot is burned against a machine that no longer exists and
+      # has to be revoked by hand. Always return it.
+      - uses: game-ci/unity-return-license@v2
+        if: always()
+        continue-on-error: true
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,8 +103,11 @@ jobs:
       # Every container is a new machine to Unity, so each run consumes an activation. If a run
       # dies before returning it, that slot is burned against a machine that no longer exists and
       # has to be revoked by hand. Always return it.
+      # GameCI's own post step returns the license on a clean run; it is only known to fail when
+      # the run is interrupted (unity-builder#538). Running this unconditionally costs ~70s a job
+      # to repeat work already done, so restrict it to the case it exists for.
       - uses: game-ci/unity-return-license@v2
-        if: always()
+        if: failure() || cancelled()
         continue-on-error: true
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -230,8 +233,11 @@ jobs:
           manualExit: true
           versioning: None
 
+      # GameCI's own post step returns the license on a clean run; it is only known to fail when
+      # the run is interrupted (unity-builder#538). Running this unconditionally costs ~70s a job
+      # to repeat work already done, so restrict it to the case it exists for.
       - uses: game-ci/unity-return-license@v2
-        if: always()
+        if: failure() || cancelled()
         continue-on-error: true
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -125,6 +125,10 @@ namespace BugSplatUnity
         /// </summary>
         public string Description
         {
+            get
+            {
+                return clientSettings.Description;
+            }
             set
             {
                 clientSettings.Description = value;
@@ -137,6 +141,10 @@ namespace BugSplatUnity
         /// </summary>
         public string Email
         {
+            get
+            {
+                return clientSettings.Email;
+            }
             set
             {
                 clientSettings.Email = value;
@@ -149,6 +157,10 @@ namespace BugSplatUnity
         /// </summary>
         public string Key
         {
+            get
+            {
+                return clientSettings.Key;
+            }
             set
             {
                 clientSettings.Key = value;
@@ -176,6 +188,10 @@ namespace BugSplatUnity
         /// </summary>
         public string Notes
         {
+            get
+            {
+                return clientSettings.Notes;
+            }
             set
             {
                 clientSettings.Notes = value;
@@ -188,6 +204,10 @@ namespace BugSplatUnity
         /// </summary>
         public string User
         {
+            get
+            {
+                return clientSettings.User;
+            }
             set
             {
                 clientSettings.User = value;

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -394,6 +394,19 @@ namespace BugSplatUnity
                 PostExceptionsInEditor = options.PostExceptionsInEditor
             };
 
+            if (options.Attributes != null)
+            {
+                foreach (var attribute in options.Attributes)
+                {
+                    if (attribute == null || string.IsNullOrEmpty(attribute.Name))
+                    {
+                        continue;
+                    }
+
+                    bugSplat.Attributes[attribute.Name] = attribute.Value ?? string.Empty;
+                }
+            }
+
             bugSplat.SetWindowsCrashDialogEnabled(options.WindowsShowCrashDialog);
 
             if (options.WindowsHangDetectionTimeoutMs > 0)

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -1,8 +1,20 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace BugSplatUnity.Runtime.Client
 {
+	/// <summary>
+	/// A single report attribute. Unity cannot serialize a Dictionary, so attributes are authored
+	/// as a list of pairs.
+	/// </summary>
+	[Serializable]
+	public class BugSplatAttribute
+	{
+		public string Name;
+		public string Value;
+	}
+
 	[CreateAssetMenu(menuName = "BugSplat Options")]
 	public class BugSplatOptions : ScriptableObject
 	{
@@ -50,7 +62,7 @@ namespace BugSplatUnity.Runtime.Client
 		public List<string> PersistentDataFileAttachmentPaths;
 
 		[Tooltip("Attributes to attach to reports")]
-		public Dictionary<string, string> Attributes;
+		public List<BugSplatAttribute> Attributes = new List<BugSplatAttribute>();
 		
 		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page")]
 		public string SymbolUploadClientId;

--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -309,11 +309,11 @@ namespace BugSplatUnity.Runtime.Reporter
         }
 
         // Copy to a temp file to avoid sharing exception
-        private FileInfo CopyLogTailToTempFile(FileInfo logFileInfo, int tailMaxSizeMB)
+        internal FileInfo CopyLogTailToTempFile(FileInfo logFileInfo, int tailMaxSizeMB)
         {
             if (logFileInfo == null || !logFileInfo.Exists)
             {
-                Debug.LogError($"Log file does not exist at {logFileInfo.FullName}, skipping...");
+                Debug.LogError($"Log file does not exist at {logFileInfo?.FullName}, skipping...");
                 return null;
             }
 

--- a/Runtime/Settings/IClientSettingsRepository.cs
+++ b/Runtime/Settings/IClientSettingsRepository.cs
@@ -12,9 +12,7 @@ namespace BugSplatUnity.Runtime.Settings
         bool CapturePlayerLog { get; set; }
         bool CaptureScreenshots { get; set; }
         bool PostExceptionsInEditor { get; set; }
-#if !UNITY_WEBGL
         int LogFileMaxSizeMB { get; set; }
-#endif
         Func<Exception, bool> ShouldPostException { get; set; }
         string Description { get; set; }
         string Email { get; set; }

--- a/Runtime/Settings/WebGLClientSettingsRepository.cs
+++ b/Runtime/Settings/WebGLClientSettingsRepository.cs
@@ -5,7 +5,6 @@ using System.IO;
 
 namespace BugSplatUnity.Runtime.Settings
 {
-#if UNITY_WEBGL
     internal class WebGLClientSettingsRepository : IClientSettingsRepository
     {
         // TODO BG what do we do about attachments here...
@@ -16,6 +15,7 @@ namespace BugSplatUnity.Runtime.Settings
         public bool CapturePlayerLog { get; set; } = false;
         public bool CaptureScreenshots { get; set; } = false;
         public bool PostExceptionsInEditor { get; set; } = true;
+        public int LogFileMaxSizeMB { get; set; } = 10;
         public Func<Exception, bool> ShouldPostException { get; set; } = ShouldPostExceptionImpl.DefaultShouldPostExceptionImpl;
         public string Description { get; set; }
         public string Email { get; set; }
@@ -23,5 +23,4 @@ namespace BugSplatUnity.Runtime.Settings
         public string Notes { get; set; }
         public string User { get; set; }
     }
-#endif
 }

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
@@ -1,0 +1,100 @@
+using BugSplatUnity.Runtime.Client;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace BugSplatUnity.RuntimeTests
+{
+	public class BugSplatCreateFromOptionsTests
+	{
+		BugSplatOptions options;
+
+		[SetUp]
+		public void SetUp()
+		{
+			options = ScriptableObject.CreateInstance<BugSplatOptions>();
+			options.Database = "database";
+			options.Application = "application";
+			options.Version = "version";
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Object.DestroyImmediate(options);
+		}
+
+		// Every value is deliberately set away from its default. Asserting a field that already
+		// holds the value it would have had anyway passes whether or not the mapping exists.
+		[Test]
+		public void CreateFromOptions_ShouldCopyEveryConfiguredValue()
+		{
+			options.Description = "description";
+			options.Email = "fred@bugsplat.com";
+			options.Key = "key";
+			options.Notes = "notes";
+			options.User = "fred";
+			options.CaptureEditorLog = true;
+			options.CapturePlayerLog = true;
+			options.CaptureScreenshots = true;
+			options.LogFileMaxSizeMB = 42;
+			options.PostExceptionsInEditor = false;
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual("description", sut.Description, nameof(options.Description));
+			Assert.AreEqual("fred@bugsplat.com", sut.Email, nameof(options.Email));
+			Assert.AreEqual("key", sut.Key, nameof(options.Key));
+			Assert.AreEqual("notes", sut.Notes, nameof(options.Notes));
+			Assert.AreEqual("fred", sut.User, nameof(options.User));
+			Assert.True(sut.CaptureEditorLog, nameof(options.CaptureEditorLog));
+			Assert.True(sut.CapturePlayerLog, nameof(options.CapturePlayerLog));
+			Assert.True(sut.CaptureScreenshots, nameof(options.CaptureScreenshots));
+			Assert.AreEqual(42, sut.LogFileMaxSizeMB, nameof(options.LogFileMaxSizeMB));
+			Assert.False(sut.PostExceptionsInEditor, nameof(options.PostExceptionsInEditor));
+		}
+
+		// The constructor throws on an empty application, so completing at all is what proves the
+		// fallback ran.
+		[Test]
+		public void CreateFromOptions_WhenApplicationIsEmpty_ShouldFallBackToProductName()
+		{
+			Assume.That(Application.productName, Is.Not.Empty);
+			options.Application = string.Empty;
+
+			Assert.DoesNotThrow(() => BugSplat.CreateFromOptions(options));
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenVersionIsEmpty_ShouldFallBackToApplicationVersion()
+		{
+			Assume.That(Application.version, Is.Not.Empty);
+			options.Version = string.Empty;
+
+			Assert.DoesNotThrow(() => BugSplat.CreateFromOptions(options));
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenPersistentDataFileAttachmentPathsIsNull_ShouldNotThrow()
+		{
+			options.PersistentDataFileAttachmentPaths = null;
+
+			Assert.DoesNotThrow(() => BugSplat.CreateFromOptions(options));
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttachmentDoesNotExist_ShouldSkipIt()
+		{
+			options.PersistentDataFileAttachmentPaths = new System.Collections.Generic.List<string>
+			{
+				"does-not-exist.txt"
+			};
+
+			LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.IsEmpty(sut.Attachments);
+		}
+	}
+}

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
@@ -75,6 +75,58 @@ namespace BugSplatUnity.RuntimeTests
 		}
 
 		[Test]
+		public void CreateFromOptions_ShouldCopyAttributes()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "level", Value = "boss" },
+				new BugSplatAttribute { Name = "difficulty", Value = "hard" }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(2, sut.Attributes.Count);
+			Assert.AreEqual("boss", sut.Attributes["level"]);
+			Assert.AreEqual("hard", sut.Attributes["difficulty"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributeNameIsEmpty_ShouldSkipIt()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "", Value = "orphaned" },
+				new BugSplatAttribute { Name = "kept", Value = "value" }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(1, sut.Attributes.Count);
+			Assert.AreEqual("value", sut.Attributes["kept"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributeValueIsNull_ShouldUseEmptyString()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "name", Value = null }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(string.Empty, sut.Attributes["name"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributesIsNull_ShouldNotThrow()
+		{
+			options.Attributes = null;
+
+			Assert.DoesNotThrow(() => BugSplat.CreateFromOptions(options));
+		}
+
+		[Test]
 		public void CreateFromOptions_WhenPersistentDataFileAttachmentPathsIsNull_ShouldNotThrow()
 		{
 			options.PersistentDataFileAttachmentPaths = null;

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs.meta
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13857baf9760e2d4b8d966d773163c52

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
@@ -1,0 +1,126 @@
+using BugSplatUnity.Runtime.Reporter;
+using BugSplatUnity.Runtime.Settings;
+using BugSplatUnity.RuntimeTests.Reporter.Fakes;
+using NUnit.Framework;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace BugSplatUnity.RuntimeTests.Reporter
+{
+	public class CopyLogTailToTempFileTests
+	{
+		const int OneMegabyte = 1024 * 1024;
+
+		DotNetStandardExceptionReporter sut;
+		string workingDirectory;
+
+		[SetUp]
+		public void SetUp()
+		{
+			sut = new DotNetStandardExceptionReporter(
+				new WebGLClientSettingsRepository(),
+				new FakeDotNetExceptionClient(new HttpResponseMessage()));
+
+			workingDirectory = Path.Combine(Path.GetTempPath(), "bugsplat-log-tail-tests", Path.GetRandomFileName());
+			Directory.CreateDirectory(workingDirectory);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (Directory.Exists(workingDirectory))
+			{
+				Directory.Delete(workingDirectory, true);
+			}
+		}
+
+		FileInfo WriteLog(string name, byte[] contents)
+		{
+			var path = Path.Combine(workingDirectory, name);
+			File.WriteAllBytes(path, contents);
+			return new FileInfo(path);
+		}
+
+		static byte[] Repeating(int length)
+		{
+			var bytes = new byte[length];
+			for (var i = 0; i < length; i++)
+			{
+				// Position-dependent so a copy taken from the wrong offset is detectable.
+				bytes[i] = (byte)(i % 251);
+			}
+			return bytes;
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileIsSmallerThanMax_ShouldCopyAllOfIt()
+		{
+			var contents = Encoding.UTF8.GetBytes("a small log file");
+			var log = WriteLog("Player.log", contents);
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.NotNull(result);
+			Assert.AreEqual(contents.Length, result.Length);
+			CollectionAssert.AreEqual(contents, File.ReadAllBytes(result.FullName));
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileExceedsMax_ShouldCopyOnlyTheTail()
+		{
+			var contents = Repeating(2 * OneMegabyte + 4096);
+			var log = WriteLog("Player.log", contents);
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.NotNull(result);
+			Assert.AreEqual(OneMegabyte, result.Length, "should be truncated to exactly the max size");
+
+			var expectedTail = new byte[OneMegabyte];
+			System.Array.Copy(contents, contents.Length - OneMegabyte, expectedTail, 0, OneMegabyte);
+			CollectionAssert.AreEqual(expectedTail, File.ReadAllBytes(result.FullName), "should be the end of the file, not the start");
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_ShouldKeepTheOriginalFileName()
+		{
+			var log = WriteLog("Editor.log", Encoding.UTF8.GetBytes("contents"));
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.AreEqual("Editor.log", result.Name);
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_ShouldNotModifyTheSourceFile()
+		{
+			var contents = Repeating(2 * OneMegabyte);
+			var log = WriteLog("Player.log", contents);
+
+			sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.AreEqual(contents.Length, new FileInfo(log.FullName).Length);
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileDoesNotExist_ShouldReturnNull()
+		{
+			var missing = new FileInfo(Path.Combine(workingDirectory, "missing.log"));
+
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			Assert.Null(sut.CopyLogTailToTempFile(missing, 1));
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileInfoIsNull_ShouldReturnNull()
+		{
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			Assert.Null(sut.CopyLogTailToTempFile(null, 1));
+		}
+	}
+}

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs.meta
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3ed07662a07097429748640dd72fcaf


### PR DESCRIPTION
Stacked on #123 (`base: feat/windows-native-crash-reporting`). Merge #123 first, or merge this into that branch.

## The test suite has not been runnable

It failed to compile on **every** build target, from two guards that disagreed about where `LogFileMaxSizeMB` lives:

- **Non-WebGL targets** — `DotNetStandardExceptionReporterTests`, `ReportUploadGuardServiceTests`, and `WebGLReporterTests` all reference `WebGLClientSettingsRepository`, which was compiled out by `#if UNITY_WEBGL`.
- **WebGL** — `BugSplat.cs` and `DotNetStandardExceptionReporter.cs` read `IClientSettingsRepository.LogFileMaxSizeMB`, declared behind `#if !UNITY_WEBGL`.

Neither guard could be satisfied at once, so there was no target on which the tests built. This predates #123 — it traces back to #110/#117.

The fix puts `LogFileMaxSizeMB` on the interface unconditionally and has `WebGLClientSettingsRepository` implement it. The class stays `internal` and is still only constructed under `#elif UNITY_WEBGL` in `BugSplat.cs`, but it now compiles everywhere so the tests can reference it.

## One test was failing, and it was a real race

With the suite running, `LogMessageReceived_WhenReportUploadGuardServiceReturnsTrue_ShouldCallPostWithStackTraceAndOptions` failed intermittently — 43/44 on one run, 44/44 on the next, same code.

The cause is in the product, not the test. `DotNetStandardExceptionReporter.Post` ended with:

```csharp
yield return Task.Run(async () => { ... });
```

Unity's coroutine scheduler doesn't understand `System.Threading.Tasks.Task`, so yielding one waits a **single frame** rather than for the task. The coroutine could complete before the upload had actually happened. It usually won the race against a fake client, which is why it only failed sometimes.

It now polls the task, matching the pattern already used in `BugSplat.PostFeedback`:

```csharp
while (!post.IsCompleted)
{
    yield return null;
}
```

and reads `post.Exception` when faulted, so an unobserved task exception can't resurface on the finalizer thread.

**This is a behaviour change worth a look:** callers yielding on `Post`/`LogMessageReceived` now actually wait for the upload instead of resuming after one frame. That is the intended contract, but it is a change.

## CI

`.github/workflows/tests.yml` runs the suite on `StandaloneLinux64` and `WebGL` on every PR and on pushes to `main`. No custom runner is needed — the tests are plain NUnit with no native dependencies, so GameCI's Linux images are enough.

This repo is a UPM package rather than a Unity project, so the workflow generates a host project that embeds it via `file:` and lists it under `testables`.

**Setup required before this goes green: add a `UNITY_LICENSE` secret** (the contents of a `.ulf` activation file). Also confirm `UNITY_VERSION` (currently `6000.0.81f1`) is a tag GameCI publishes.

## Verification

Unity 6000.5.6f1 locally, via a generated host project:

| Target | Result |
| --- | --- |
| Win64 | 44/44 passed (run twice) |
| WebGL | 44/44 passed, clean compile |

The workflow itself has not run yet — it can't until the license secret exists.

## Not addressed here

While checking whether the new `Debug.LogError` could feed back into the reporter (it can't — `ShouldPostLogMessage` only admits `LogType.Exception`), I found that the nine `Debug.LogException` calls in this file *do* pass that guard. Seven are inside `Post`'s log-attachment block, before any `yield`, so a persistently failing log copy re-enters `Post` synchronously through `logMessageReceived` and grows the stack. `ShouldPostExceptionImpl`'s static 3s rate limiter breaks the chain today, but that brake is gone for anyone overriding `ShouldPostException` to always return true — which the sample does. Pre-existing and left alone; worth its own issue.