### PR TITLE
fix: apply the attributes configured on BugSplatOptions

### DIFF
--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -394,6 +394,19 @@ namespace BugSplatUnity
                 PostExceptionsInEditor = options.PostExceptionsInEditor
             };
 
+            if (options.Attributes != null)
+            {
+                foreach (var attribute in options.Attributes)
+                {
+                    if (attribute == null || string.IsNullOrEmpty(attribute.Name))
+                    {
+                        continue;
+                    }
+
+                    bugSplat.Attributes[attribute.Name] = attribute.Value ?? string.Empty;
+                }
+            }
+
             bugSplat.SetWindowsCrashDialogEnabled(options.WindowsShowCrashDialog);
 
             if (options.WindowsHangDetectionTimeoutMs > 0)

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -1,8 +1,20 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace BugSplatUnity.Runtime.Client
 {
+	/// <summary>
+	/// A single report attribute. Unity cannot serialize a Dictionary, so attributes are authored
+	/// as a list of pairs.
+	/// </summary>
+	[Serializable]
+	public class BugSplatAttribute
+	{
+		public string Name;
+		public string Value;
+	}
+
 	[CreateAssetMenu(menuName = "BugSplat Options")]
 	public class BugSplatOptions : ScriptableObject
 	{
@@ -50,7 +62,7 @@ namespace BugSplatUnity.Runtime.Client
 		public List<string> PersistentDataFileAttachmentPaths;
 
 		[Tooltip("Attributes to attach to reports")]
-		public Dictionary<string, string> Attributes;
+		public List<BugSplatAttribute> Attributes = new List<BugSplatAttribute>();
 		
 		[Tooltip("OAuth2 Client ID generated on BugSplat's Integrations page")]
 		public string SymbolUploadClientId;

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
@@ -75,6 +75,58 @@ namespace BugSplatUnity.RuntimeTests
 		}
 
 		[Test]
+		public void CreateFromOptions_ShouldCopyAttributes()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "level", Value = "boss" },
+				new BugSplatAttribute { Name = "difficulty", Value = "hard" }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(2, sut.Attributes.Count);
+			Assert.AreEqual("boss", sut.Attributes["level"]);
+			Assert.AreEqual("hard", sut.Attributes["difficulty"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributeNameIsEmpty_ShouldSkipIt()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "", Value = "orphaned" },
+				new BugSplatAttribute { Name = "kept", Value = "value" }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(1, sut.Attributes.Count);
+			Assert.AreEqual("value", sut.Attributes["kept"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributeValueIsNull_ShouldUseEmptyString()
+		{
+			options.Attributes = new System.Collections.Generic.List<BugSplatAttribute>
+			{
+				new BugSplatAttribute { Name = "name", Value = null }
+			};
+
+			var sut = BugSplat.CreateFromOptions(options);
+
+			Assert.AreEqual(string.Empty, sut.Attributes["name"]);
+		}
+
+		[Test]
+		public void CreateFromOptions_WhenAttributesIsNull_ShouldNotThrow()
+		{
+			options.Attributes = null;
+
+			Assert.DoesNotThrow(() => BugSplat.CreateFromOptions(options));
+		}
+
+		[Test]
 		public void CreateFromOptions_WhenPersistentDataFileAttachmentPathsIsNull_ShouldNotThrow()
 		{
 			options.PersistentDataFileAttachmentPaths = null;


### PR DESCRIPTION
> Stacks on #133 (`fix/test-compilation-and-ci`) and targets that branch.

Closes #134.

## What was broken

`BugSplatOptions.Attributes` had no effect. `CreateFromOptions` copies ten fields plus the Windows settings and the persistent-data attachments, but never read this one — so attributes authored on the asset never reached a report, with no error anywhere.

It could not have worked regardless: the field was a `Dictionary<string, string>`, which Unity cannot serialize, so it was unset from the inspector no matter what. Unity said so on every build:

```
Runtime/Client/BugSplatOptions.cs(53,37): warning UAC1009: Field 'Attributes' uses an
unsupported type 'System.Collections.Generic.Dictionary<string, string>'.
```

## The fix

Attributes are now authored as a list of name/value pairs, which serializes, and are copied onto the client in `CreateFromOptions`:

```csharp
[Serializable]
public class BugSplatAttribute
{
    public string Name;
    public string Value;
}
```

Entries with no name are skipped and a null value becomes an empty string, so a half-filled inspector row can't produce a malformed attribute rather than failing at post time.

## Breaking change

`BugSplatOptions.Attributes` is now `List<BugSplatAttribute>` instead of `Dictionary<string, string>`. Code assigning a dictionary to it will no longer compile — though that code could never have had any effect, and the inspector could never populate it at all. Landing it in 5.0.0 alongside the other breaking changes seems right; say the word if you'd rather keep a dictionary-shaped API alongside the serialized list.

`bugsplat.Attributes` — the runtime dictionary used by `BugSplatSettings.cs` in the sample — is untouched.

## Tests

Four cases added to `BugSplatCreateFromOptionsTests`: pairs are copied, nameless entries are skipped, a null value becomes empty, and a null list doesn't throw.

**53/53 passing** locally on Unity 6000.5.6f1 (49 existing plus these four).

## Note on the stack

This targets #133, which currently duplicates #129 and #130. If #133 is rebased to shed those commits, this branch will need rebasing with it.