### PR TITLE
test: cover the log tail truncation, and fix its null guard

### DIFF
--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -309,11 +309,11 @@ namespace BugSplatUnity.Runtime.Reporter
         }
 
         // Copy to a temp file to avoid sharing exception
-        private FileInfo CopyLogTailToTempFile(FileInfo logFileInfo, int tailMaxSizeMB)
+        internal FileInfo CopyLogTailToTempFile(FileInfo logFileInfo, int tailMaxSizeMB)
         {
             if (logFileInfo == null || !logFileInfo.Exists)
             {
-                Debug.LogError($"Log file does not exist at {logFileInfo.FullName}, skipping...");
+                Debug.LogError($"Log file does not exist at {logFileInfo?.FullName}, skipping...");
                 return null;
             }
 

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
@@ -1,0 +1,126 @@
+using BugSplatUnity.Runtime.Reporter;
+using BugSplatUnity.Runtime.Settings;
+using BugSplatUnity.RuntimeTests.Reporter.Fakes;
+using NUnit.Framework;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace BugSplatUnity.RuntimeTests.Reporter
+{
+	public class CopyLogTailToTempFileTests
+	{
+		const int OneMegabyte = 1024 * 1024;
+
+		DotNetStandardExceptionReporter sut;
+		string workingDirectory;
+
+		[SetUp]
+		public void SetUp()
+		{
+			sut = new DotNetStandardExceptionReporter(
+				new WebGLClientSettingsRepository(),
+				new FakeDotNetExceptionClient(new HttpResponseMessage()));
+
+			workingDirectory = Path.Combine(Path.GetTempPath(), "bugsplat-log-tail-tests", Path.GetRandomFileName());
+			Directory.CreateDirectory(workingDirectory);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (Directory.Exists(workingDirectory))
+			{
+				Directory.Delete(workingDirectory, true);
+			}
+		}
+
+		FileInfo WriteLog(string name, byte[] contents)
+		{
+			var path = Path.Combine(workingDirectory, name);
+			File.WriteAllBytes(path, contents);
+			return new FileInfo(path);
+		}
+
+		static byte[] Repeating(int length)
+		{
+			var bytes = new byte[length];
+			for (var i = 0; i < length; i++)
+			{
+				// Position-dependent so a copy taken from the wrong offset is detectable.
+				bytes[i] = (byte)(i % 251);
+			}
+			return bytes;
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileIsSmallerThanMax_ShouldCopyAllOfIt()
+		{
+			var contents = Encoding.UTF8.GetBytes("a small log file");
+			var log = WriteLog("Player.log", contents);
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.NotNull(result);
+			Assert.AreEqual(contents.Length, result.Length);
+			CollectionAssert.AreEqual(contents, File.ReadAllBytes(result.FullName));
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileExceedsMax_ShouldCopyOnlyTheTail()
+		{
+			var contents = Repeating(2 * OneMegabyte + 4096);
+			var log = WriteLog("Player.log", contents);
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.NotNull(result);
+			Assert.AreEqual(OneMegabyte, result.Length, "should be truncated to exactly the max size");
+
+			var expectedTail = new byte[OneMegabyte];
+			System.Array.Copy(contents, contents.Length - OneMegabyte, expectedTail, 0, OneMegabyte);
+			CollectionAssert.AreEqual(expectedTail, File.ReadAllBytes(result.FullName), "should be the end of the file, not the start");
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_ShouldKeepTheOriginalFileName()
+		{
+			var log = WriteLog("Editor.log", Encoding.UTF8.GetBytes("contents"));
+
+			var result = sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.AreEqual("Editor.log", result.Name);
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_ShouldNotModifyTheSourceFile()
+		{
+			var contents = Repeating(2 * OneMegabyte);
+			var log = WriteLog("Player.log", contents);
+
+			sut.CopyLogTailToTempFile(log, 1);
+
+			Assert.AreEqual(contents.Length, new FileInfo(log.FullName).Length);
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileDoesNotExist_ShouldReturnNull()
+		{
+			var missing = new FileInfo(Path.Combine(workingDirectory, "missing.log"));
+
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			Assert.Null(sut.CopyLogTailToTempFile(missing, 1));
+		}
+
+		[Test]
+		public void CopyLogTailToTempFile_WhenFileInfoIsNull_ShouldReturnNull()
+		{
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			Assert.Null(sut.CopyLogTailToTempFile(null, 1));
+		}
+	}
+}

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs.meta
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3ed07662a07097429748640dd72fcaf


### PR DESCRIPTION
> Stacks on #133 (`fix/test-compilation-and-ci`) and targets that branch.

First slice of #135 — the coverage that doesn't require the `INativeCrashBridge` refactor, so it can land without waiting for the #123 stack.

## Why this one first

`CopyLogTailToTempFile` implements the log truncation from #110 and had no coverage at all. It decides how much of a log file gets uploaded, and the failure mode is quiet: seek from the wrong end and you ship the *start* of a log rather than the end — the part that actually describes the crash. Nothing would throw, and the report would look fine.

## A bug the tests found

```csharp
if (logFileInfo == null || !logFileInfo.Exists)
{
    Debug.LogError($"Log file does not exist at {logFileInfo.FullName}, skipping...");
```

The null check short-circuits straight into a block that dereferences the same argument, so passing null threw `NullReferenceException` instead of returning null. The guard could never do its job. Now uses `logFileInfo?.FullName`.

## Coverage

- a file under the limit is copied whole
- a file over the limit is truncated to exactly the limit, **and the bytes are the tail, not the head**
- the original filename is preserved (it becomes the attachment name)
- the source file is left untouched
- a missing file returns null and logs
- a null `FileInfo` returns null and logs

The content assertions use position-dependent bytes (`i % 251`) rather than a repeated pattern — with uniform filler, a copy taken from the wrong offset would compare equal and the test would pass by coincidence.

`CopyLogTailToTempFile` is now `internal` rather than `private`; the test assembly already has `InternalsVisibleTo`.

**55/55 passing** locally on Unity 6000.5.6f1 (49 existing plus these six).

## Still open on #135

The `INativeCrashBridge` refactor and the native-init policy tests, which rewrite the same `BugSplat.cs` regions #123 is changing and should wait for that stack. Plus `DotNetStandardClientSettingsRepository`, `FileContentsWriter`, `WrappedDirectoryInfo`, and `WerRegistration.NormalizeWerDllPath` — the last needs an editor test assembly, which doesn't exist yet.

## Note on the stack

Targets #133, which currently duplicates #129 and #130. If #133 is rebased to shed those commits, this branch needs rebasing with it.