### PR TITLE
fix(apple): implement SetNativeKey via the bugsplat-apple appKey API

### DIFF
--- a/Editor/IOS/ObjC/BugSplatBridge.mm
+++ b/Editor/IOS/ObjC/BugSplatBridge.mm
@@ -41,6 +41,10 @@ extern "C" {
 		[BugSplat shared].notes = createNSStringFrom(notes);
 	}
 
+	void _setNativeKeyIos(const char* key) {
+		[BugSplat shared].appKey = createNSStringFrom(key);
+	}
+
 	void _attachNativeLogFileIos(const char* path) {
 		// Log file attachment is not supported on iOS because the BugSplatDelegate's
 		// attachmentForBugSplat: method suppresses attributes from setValue:forAttribute:.

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -620,12 +620,18 @@ namespace BugSplatUnity
         }
 
         /// <summary>
-        /// Set the key on the native crash reporter. Supported on Windows and Android; no-op on iOS and macOS.
+        /// Set the key on the native crash reporter. iOS, macOS, and Windows use the platform SDK's own
+        /// key setter; Android's bridge has none, so there the key travels as the reserved
+        /// BugSplatApplicationKey attribute that the backend promotes to the report's key.
         /// </summary>
         public void SetNativeKey(string key)
         {
             if (!nativeCrashReportingEnabled) return;
-#if UNITY_STANDALONE_WIN && !UNITY_EDITOR
+#if UNITY_IOS && !UNITY_EDITOR
+            _setNativeKeyIos(key);
+#elif UNITY_STANDALONE_OSX && !UNITY_EDITOR
+            _setNativeKeyMac(key);
+#elif UNITY_STANDALONE_WIN && !UNITY_EDITOR
             BugSplat_SetKey(key);
 #elif UNITY_ANDROID && !UNITY_EDITOR
             var javaClass = new AndroidJavaClass("com.bugsplat.android.BugSplatBridge");
@@ -745,6 +751,9 @@ namespace BugSplatUnity
         static extern void _setNativeNotesIos(string notes);
 
         [DllImport("__Internal")]
+        static extern void _setNativeKeyIos(string key);
+
+        [DllImport("__Internal")]
         static extern void _attachNativeLogFileIos(string path);
 #elif UNITY_STANDALONE_OSX && !UNITY_EDITOR
         [DllImport("__Internal")]
@@ -761,6 +770,9 @@ namespace BugSplatUnity
 
         [DllImport("__Internal")]
         static extern void _setNativeNotesMac(string notes);
+
+        [DllImport("__Internal")]
+        static extern void _setNativeKeyMac(string key);
 
         [DllImport("__Internal")]
         static extern void _attachNativeLogFileMac(string path);

--- a/Runtime/Plugins/macOS/BugSplatBridgeMac.mm
+++ b/Runtime/Plugins/macOS/BugSplatBridgeMac.mm
@@ -187,6 +187,12 @@ extern "C" {
         [bugsplat setValue:[NSString stringWithUTF8String:(notes ?: "")] forKey:@"notes"];
     }
 
+    void _setNativeKeyMac(const char* key) {
+        id bugsplat = GetBugSplatInstance();
+        if (!bugsplat) return;
+        [bugsplat setValue:[NSString stringWithUTF8String:(key ?: "")] forKey:@"appKey"];
+    }
+
     void _attachNativeLogFileMac(const char* path) {
         _logFilePath = [NSString stringWithUTF8String:(path ?: "")];
 


### PR DESCRIPTION
Closes #138

Stacked on #123 — base is `feat/windows-native-crash-reporting`. Review the [single commit](https://github.com/BugSplat-Git/bugsplat-unity/pull/147/commits), not the diff against `main`.

## Problem

After #128, `SetNativeKey` worked on Windows (`BugSplat_SetKey`) and Android (reserved-attribute promotion), but the iOS and macOS branches didn't exist — the method compiled down to nothing but the `nativeCrashReportingEnabled` guard and a `ret`. Every Apple native report carried whatever key the backend defaulted to.

That matters because key drives grouping. The sample sets a distinct `Key` before each scenario precisely because reports that fault identically would otherwise collapse into a single bucket, and #123 notes it's the only thing identifying which scenario produced a report on Mono. Apple platforms got none of that.

## Fix

bugsplat-apple exposes a first-class `appKey` property, so this uses it rather than promoting a reserved attribute:

```objc
// Editor/IOS/ObjC/BugSplatBridge.mm
void _setNativeKeyIos(const char* key) {
    [BugSplat shared].appKey = createNSStringFrom(key);
}

// Runtime/Plugins/macOS/BugSplatBridgeMac.mm
void _setNativeKeyMac(const char* key) {
    id bugsplat = GetBugSplatInstance();
    if (!bugsplat) return;
    [bugsplat setValue:[NSString stringWithUTF8String:(key ?: "")] forKey:@"appKey"];
}
```

The macOS bridge resolves the BugSplat class at runtime out of the dylib, so it sets the property by KVC exactly as it already does for `userName`, `userEmail`, and `notes`. `SetNativeKey` then routes to the new externs, and the platform order matches the other four `SetNative*` setters.

`appKey` is documented as *"captured at crash time and included with the crash report"* — unlike `userName`/`userEmail`, which carry a "must be set before `start`" warning — so setting it post-init, which is what `bugsplat.Key = ...` does, is the supported usage.

### Why not the reserved-attribute route

The issue proposed sending the key as a `BugSplatApplicationKey` attribute, mirroring Android. **That was the wrong call, and the first push of this PR did it.** Attribute promotion is a workaround for a bridge with no setter, and Android is the only platform that fits: its `BugSplatBridge` really does expose only `setAttribute`/`removeAttribute` (`javap` on the vendored `.aar` confirms — `initBugSplat`, `crash`, `hang`, `setAttribute`, `removeAttribute`, nothing else).

Apple isn't in that position, and the direct property is strictly better: it depends on no backend attribute handling, and it doesn't ride on the `CrashContext.xml` attachment that bugsplat-apple bundles attributes into — a payload that on iOS survives only because `_attachNativeLogFileIos` is deliberately stubbed, since iOS accepts a single attachment.

No sample or README change is needed — the sample already sets `Key` on every scenario via `CrashScenarios.Describe`, and the README never claimed the key was Windows-only.

## Verification

No Unity project build was run — this is code inside `!UNITY_EDITOR` blocks and native bridges, which the editor test suite cannot link against, let alone execute. Instead each piece was compiled directly against the real vendored dependencies and the output inspected.

**C#** — runtime sources compiled against Unity 6000.3.5f2 player assemblies per target:

| Target defines | Result |
|---|---|
| `UNITY_IOS` | 0 errors; `SetNativeKey` emits `call _setNativeKeyIos` |
| `UNITY_STANDALONE_OSX` | 0 errors; emits `call _setNativeKeyMac` |
| `UNITY_STANDALONE_WIN`\* | 0 errors; still emits `call BugSplat_SetKey` |
| `UNITY_ANDROID` | 0 errors |

Only the two pre-existing `CS0649` warnings appeared, on both sides of the change.

**Objective-C++** — both bridges compiled with `clang`:

- iOS bridge against the vendored `BugSplat.xcframework/ios-arm64` header — 0 errors, so `[BugSplat shared].appKey` type-checks against the shipped API. `nm` shows `__setNativeKeyIos` exported and `_objc_msgSend$setAppKey:` referenced. Only warning is the pre-existing unknown-`#pragma ide` one.
- macOS bridge for `arm64` — 0 errors, `__setNativeKeyMac` exported, `appKey` present as a KVC key string.

**The dylib actually has the selector** — `otool -oV Runtime/Plugins/macOS/BugSplat-macOS.dylib` lists `-[BugSplat setAppKey:]` and `-[BugSplat appKey]`, so the KVC lookup resolves rather than raising `NSUnknownKeyException`.

CI's `Compile iOS` job exercises the iOS C# branch for real. **There is no equivalent macOS player-script compile job** — the `StandaloneOSX` job runs editor tests, which exclude every `!UNITY_EDITOR` block. Adding `StandaloneOSX` to the `compile` matrix would close that gap, but each job burns another serialized Unity activation on a run that already budgets 60–90 minutes, so it's left out of this PR.

**Not verified: an actual crash report.** No Apple crash was uploaded and no backend report inspected, so "the key shows up on the report" rests on the API contract and the symbol checks above, not on an observed report. Worth confirming before 5.0.0 ships:

- [ ] iOS: set `Key`, crash natively, confirm the uploaded report's key matches
- [ ] macOS: same, and confirm `Player.log` still attaches

\* The Windows player module isn't installed on the build machine, so `UNITY_STANDALONE_WIN` was compiled against the macOS standalone assemblies as a proxy. That branch is untouched code using only `DllImport` plus `Application` APIs, and CI's `StandaloneWindows64` job covers the real thing.

## Scope

`SetNativeDescription` is still Windows-only — it's the one remaining `SetNative*` variant unimplemented on Apple. bugsplat-apple has no description property (`BugSplat.h` declares `userName`, `userEmail`, `appKey`, and `notes`, and nothing else that fits), and there's no reserved attribute name for it either, so it needs an SDK change rather than a Unity one. Audit item **E3** stays partially open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
