### PR TITLE
fix(android): stop logging upload success after a failed symbol upload

### DIFF
--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -516,13 +516,13 @@ public class BuildPostprocessors
 
 		UploadSymbols(symbolsUnzipPath, "**/*.so", options, uploadExitCode =>
 		{
+			Directory.Delete(symbolsUnzipPath, true);
+
 			if (uploadExitCode != 0)
 			{
 				Debug.LogError("BugSplat. Could not upload symbols.");
+				return;
 			}
-
-			// Clean up generated debug symbols
-			Directory.Delete(symbolsUnzipPath, true);
 
 			Debug.Log("BugSplat. Symbols uploading completed.");
 		});

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -516,7 +516,14 @@ public class BuildPostprocessors
 
 		UploadSymbols(symbolsUnzipPath, "**/*.so", options, uploadExitCode =>
 		{
-			Directory.Delete(symbolsUnzipPath, true);
+			try
+			{
+				Directory.Delete(symbolsUnzipPath, true);
+			}
+			catch (Exception e)
+			{
+				Debug.LogWarning($"BugSplat. Could not clean up unzipped symbols at {symbolsUnzipPath}: {e.Message}");
+			}
 
 			if (uploadExitCode != 0)
 			{


### PR DESCRIPTION
Closes #162

## Problem

`ProcessSymbolsArchive` in `Editor/PostBuild.cs` logged `BugSplat. Could not upload symbols.` on a non-zero `symbol-upload` exit code and then fell straight through to `Debug.Log("BugSplat. Symbols uploading completed.")`. A failed Android symbol upload therefore ended the build log with a success line, so CI-red uploads read as green. The Windows (`UploadSymbolFilesWin`) and macOS (`PostProcessMac`) callbacks in the same file already `return` after their error branch.

## Fix

Return after the error branch, matching Windows and macOS.

The callback also deletes the unzipped symbols directory, and that cleanup must run whether or not the upload succeeded — so the `Directory.Delete` moved above the exit-code check instead of adding a `return` that would skip it.

```csharp
UploadSymbols(symbolsUnzipPath, "**/*.so", options, uploadExitCode =>
{
    Directory.Delete(symbolsUnzipPath, true);

    if (uploadExitCode != 0)
    {
        Debug.LogError("BugSplat. Could not upload symbols.");
        return;
    }

    Debug.Log("BugSplat. Symbols uploading completed.");
});
```

## Verification

Unity was not run. `Editor/PostBuild.cs` plus `Runtime/**` and `Editor/BugSplatSymbolUploadCredentials.cs` were compiled out-of-band with `dotnet build` against Unity 6000.5.6f1 editor assemblies, once with `UNITY_ANDROID` defined (referencing `UnityEditor.Android.Extensions.dll` and `Unity.Android.Types.dll`) and once with `UNITY_EDITOR_WIN` defined (referencing `UnityEditor.WindowsStandalone.Extensions.dll`). Both compiled with 0 errors; the only warnings are pre-existing (`SYSLIB0014` on `WebClient`, unused `_platform`, unassigned `nativeCrashReportingEnabled`/`windowsWerEnabled`).

Not verified: no real Android player build was produced, so the failure path was not exercised end to end against a live `symbol-upload` run, and the `iOS` branch was not compiled.

## Scope

Only the Android upload callback in `ProcessSymbolsArchive` is touched, to stay out of the way of the concurrent changes for #150 and #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
