### PR TITLE
fix(sample): guard BugSplatSettings against a missing BugSplatManager

### DIFF
--- a/Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs
+++ b/Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs
@@ -12,7 +12,14 @@ public class BugSplatSettings : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        bugsplat = FindAnyObjectByType<BugSplatManager>().BugSplat;
+        var manager = FindAnyObjectByType<BugSplatManager>();
+        bugsplat = manager != null ? manager.BugSplat : null;
+        if (bugsplat == null)
+        {
+            Debug.LogError("[BugSplat] BugSplatManager not found in scene. Attributes and settings will not be applied.");
+            return;
+        }
+
         bugsplat.Attributes.Add("OS", SystemInfo.operatingSystem);
         bugsplat.Attributes.Add("CPU", SystemInfo.processorType);
         bugsplat.Attributes.Add("MEMORY", $"{SystemInfo.systemMemorySize} MB");


### PR DESCRIPTION
Closes #159

## Problem

`Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs` dereferenced `FindAnyObjectByType<BugSplatManager>().BugSplat` in `Start`. Drop the sample's scripts into a scene without a `BugSplatManager` — or delete the manager while trying the sample out — and the first thing the user sees is a raw `NullReferenceException` from the sample itself, with nothing pointing at the actual cause. Every other call site in the sample already guards.

## Fix

Resolve the client the way `CrashScenarioMenu.Start` does, and when it isn't there log the same `[BugSplat] BugSplatManager not found in scene. …` message the menu (`Cannot run crash scenarios.`) and the feedback popup (`Feedback cannot be submitted.`) use, then return. Eight lines, one file, no behavior change when a manager is present.

```csharp
var manager = FindAnyObjectByType<BugSplatManager>();
bugsplat = manager != null ? manager.BugSplat : null;
if (bugsplat == null)
{
    Debug.LogError("[BugSplat] BugSplatManager not found in scene. Attributes and settings will not be applied.");
    return;
}
```

## The other null: `BugSplatManager.BugSplat` itself

`BugSplatManager.BugSplat => bugsplatRef.BugSplat` NREs inside the getter when the manager exists but `Awake` threw (`bugSplatOptions` unassigned), so `manager != null` is not by itself proof the property is safe to read.

**Decision: not fixed here.** That NRE is the runtime's, is shared identically by `CrashScenarioMenu.Start` and `FeedbackPopup.OnSubmit`, and is called out verbatim in #173 ("Missing options asset throws from `Awake` … then `BugSplatManager.BugSplat` NREs"), whose fix is graceful degrade plus build-time validation. Patching it here as a drive-by `bugsplatRef?.BugSplat` would half-close #173 and, worse, would silently swallow a misconfigured manager rather than surface it — the opposite of what that issue is asking for. Fixing it in the sample instead would mean a `try`/`catch` around a property read in example code users are meant to copy. Left as-is, deliberately, so #173 can solve it once for the runtime and all three call sites benefit.

## Verification

**What was verified:**

- The sample scripts plus the package `Runtime` sources compile clean against Unity 6000.5.6f1's assemblies (`UnityEngine.*Module`, `Unity.TextMeshPro`, `UnityEngine.UI`, `BugSplatDotNetStandard`) in a standalone `dotnet build`, under three define sets: no platform defines, `UNITY_STANDALONE_WIN`, and `UNITY_EDITOR;UNITY_EDITOR_WIN;UNITY_STANDALONE_WIN`. Zero errors in all three.
- Manual read-through of every path in `Start`: no manager in the scene → `FindAnyObjectByType` returns `null`, Unity's `!=` overload also covers a destroyed manager, error logged, early return before any `Attributes.Add`, and `bugsplat` is left `null` for the (empty) `Update`. Manager present and initialized → `BugSplatRef`'s constructor rejects a null client, so `manager.BugSplat` is non-null and the rest of `Start` runs exactly as before.
- Ordering: `Start` runs after every `Awake`, so the manager has already initialized (or already failed) by the time this reads it.

**What could NOT be verified — please exercise in the editor before merging:**

- **No Unity run of any kind.** No editor play-mode test, no player build, no scene load. The standalone `dotnet build` proves it compiles; it does not prove it behaves.
- **CI does not cover this file.** `Samples~` is excluded from compilation by Unity's tilde convention, so the test job will not compile or run this script — a green CI here says nothing about this change.
- **The intended manual repro was not run**: open the sample scene, delete the `BugSplatManager` GameObject, press Play, and confirm you get the single `[BugSplat] BugSplatManager not found in scene. Attributes and settings will not be applied.` error and no `NullReferenceException`.
- The manager-exists-but-`Awake`-threw path was reasoned about from the source, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
