### PR TITLE
fix(webgl): invoke callback when the upload guard skips a report

### DIFF
--- a/Runtime/Reporter/WebGLReporter.cs
+++ b/Runtime/Reporter/WebGLReporter.cs
@@ -28,6 +28,12 @@ namespace BugSplatUnity.Runtime.Reporter
         {
             if (!reportUploadGuardService.ShouldPostLogMessage(type))
             {
+                callback?.Invoke(new ExceptionReporterPostResult()
+                {
+                    Uploaded = false,
+                    Exception = stackTrace,
+                    Message = "BugSplat upload skipped due to ShouldPostLogMessage check.",
+                });
                 yield break;
             }
 
@@ -53,8 +59,16 @@ namespace BugSplatUnity.Runtime.Reporter
 
         public IEnumerator Post(Exception ex, IReportPostOptions options = null, Action<ExceptionReporterPostResult> callback = null)
         {
+            var stackTrace = ex.ToString();
+
             if (!reportUploadGuardService.ShouldPostException(ex))
             {
+                callback?.Invoke(new ExceptionReporterPostResult()
+                {
+                    Uploaded = false,
+                    Exception = stackTrace,
+                    Message = "BugSplat upload skipped due to ShouldPostException check.",
+                });
                 yield break;
             }
 
@@ -62,7 +76,7 @@ namespace BugSplatUnity.Runtime.Reporter
             options.SetNullOrEmptyValues(clientSettings);
             options.CrashTypeId = (int)BugSplatDotNetStandard.BugSplat.ExceptionTypeId.Unity;
 
-            yield return Post(ex.ToString(), options, callback);
+            yield return Post(stackTrace, options, callback);
         }
 
         private IEnumerator Post(string stackTrace, IReportPostOptions options = null, Action<ExceptionReporterPostResult> callback = null)

--- a/Tests/Runtime/Reporter/WebGLReporterTests.cs
+++ b/Tests/Runtime/Reporter/WebGLReporterTests.cs
@@ -39,6 +39,33 @@ namespace BugSplatUnity.RuntimeTests.Reporter
         }
 
         [UnityTest]
+        public IEnumerator LogMessageReceived_WhenReportUploadGuardServiceReturnsFalse_ShouldInvokeCallbackWithSkippedResult()
+        {
+            var logMessage = "logMessage";
+            var stackTrace = "stackTrace";
+            var clientSettings = new WebGLClientSettingsRepository
+            {
+                ShouldPostException = (ex) => false
+            };
+            var fakeExceptionClient = new FakeWebGLExceptionClient();
+            var sut = new WebGLReporter(
+                clientSettings,
+                fakeExceptionClient
+            )
+            {
+                reportUploadGuardService = new FakeFalseReportUploadGuardService()
+            };
+
+            ExceptionReporterPostResult result = null;
+            yield return sut.LogMessageReceived(logMessage, stackTrace, LogType.Exception, (postResult) => result = postResult);
+
+            Assert.NotNull(result);
+            Assert.IsFalse(result.Uploaded);
+            Assert.AreEqual(stackTrace, result.Exception);
+            Assert.AreEqual("BugSplat upload skipped due to ShouldPostLogMessage check.", result.Message);
+        }
+
+        [UnityTest]
         public IEnumerator LogMessageReceived_WhenReportUploadGuardServiceReturnsTrue_ShouldCallPostWithStackTraceAndOptions()
         {
             var logMessage = "logMessage";
@@ -82,6 +109,32 @@ namespace BugSplatUnity.RuntimeTests.Reporter
             yield return sut.Post(exception);
 
             Assert.IsEmpty(fakeExceptionClient.Calls);
+        }
+
+        [UnityTest]
+        public IEnumerator Post_WhenReportUploadGuardServiceReturnsFalse_ShouldInvokeCallbackWithSkippedResult()
+        {
+            var exception = new Exception("BugSplat rocks!");
+            var clientSettings = new WebGLClientSettingsRepository
+            {
+                ShouldPostException = (ex) => false
+            };
+            var fakeExceptionClient = new FakeWebGLExceptionClient();
+            var sut = new WebGLReporter(
+                clientSettings,
+                fakeExceptionClient
+            )
+            {
+                reportUploadGuardService = new FakeFalseReportUploadGuardService()
+            };
+
+            ExceptionReporterPostResult result = null;
+            yield return sut.Post(exception, callback: (postResult) => result = postResult);
+
+            Assert.NotNull(result);
+            Assert.IsFalse(result.Uploaded);
+            Assert.AreEqual(exception.ToString(), result.Exception);
+            Assert.AreEqual("BugSplat upload skipped due to ShouldPostException check.", result.Message);
         }
 
         [UnityTest]


### PR DESCRIPTION
Closes #165

## Problem

`WebGLReporter` did a bare `yield break` on both of its guard-skip paths, so the caller's `Action<ExceptionReporterPostResult>` was never invoked. `DotNetStandardExceptionReporter` invokes it with a skip result (`Uploaded = false` plus a "skipped" message), so the two reporters advertised the same `IExceptionReporter` contract while honouring different ones. Anything awaiting the callback to learn a report's fate hung forever on WebGL.

## Fix

Both early returns in `WebGLReporter` now invoke the callback with the same `ExceptionReporterPostResult` shape and message wording `DotNetStandardExceptionReporter` uses:

- `LogMessageReceived` -> `"BugSplat upload skipped due to ShouldPostLogMessage check."`, `Exception = stackTrace`
- `Post(Exception)` -> `"BugSplat upload skipped due to ShouldPostException check."`, `Exception = ex.ToString()`

`Post` hoists `ex.ToString()` into a local so the skip result carries the same stack trace the upload path would have sent, matching the DotNet reporter line for line.

Audited every exit in the WebGL report flow: those two `yield break`s were the only callback-less ones. `WebGLReporter.Post(string, ...)` has no early return, and `WebGLExceptionClient.PostException` already invokes the callback on both its success and failure paths.

## Tests

Added to `Tests/Runtime/Reporter/WebGLReporterTests.cs`, alongside the existing guard-returns-false tests, using the existing `FakeFalseReportUploadGuardService` / `FakeWebGLExceptionClient` fakes:

- `LogMessageReceived_WhenReportUploadGuardServiceReturnsFalse_ShouldInvokeCallbackWithSkippedResult`
- `Post_WhenReportUploadGuardServiceReturnsFalse_ShouldInvokeCallbackWithSkippedResult`

Each asserts the callback fires and that `Uploaded`, `Exception`, and `Message` match the DotNet reporter's skip result.

## Verification

`Runtime/**` + `Tests/Runtime/**` compile clean against the Unity 6000.5.6f1 managed assemblies, both with no platform define and with `UNITY_WEBGL` defined — `WebGLReporter` and `WebGLClientSettingsRepository` are compiled on all platforms, so the change had to build everywhere. 0 errors in both configurations; the only warnings are the two pre-existing `CS0649`s in `Runtime/BugSplat.cs`.

Both changed paths were also executed directly (a throwaway driver compiled into the same assembly, driving the coroutines to completion with a false guard): each invokes its callback exactly once with `Uploaded = false`, the expected message, the expected stack trace, and zero calls through to the exception client. Unity `[UnityTest]` cases were not run in the editor here; the test runner needs a licensed Unity session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
