### PR TITLE
fix: skip screenshot capture in batch mode

### DIFF
--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -246,20 +246,29 @@ namespace BugSplatUnity.Runtime.Reporter
 
             if (clientSettings.CaptureScreenshots)
             {
-                // There isn't really a safe way to do this
-                // Serializing the image to disk potentially litters the file system
-                // Capturing the image in memory potentially risks a memory exception
-                yield return new WaitForEndOfFrame();
-                var bytes = CaptureInMemoryPngScreenshot();
-                if (bytes != null)
+                // Batch mode has no render loop, so WaitForEndOfFrame never resumes and the rest of
+                // this coroutine, including the upload, would never run
+                if (isBatchMode())
                 {
-                    var param = new FormDataParam()
+                    Debug.Log("BugSplat info: CaptureScreenshots is not supported in batch mode, skipping...");
+                }
+                else
+                {
+                    // There isn't really a safe way to do this
+                    // Serializing the image to disk potentially litters the file system
+                    // Capturing the image in memory potentially risks a memory exception
+                    yield return new WaitForEndOfFrame();
+                    var bytes = CaptureInMemoryPngScreenshot();
+                    if (bytes != null)
                     {
-                        Name = "screenshot",
-                        Content = new ByteArrayContent(bytes),
-                        FileName = "screenshot.png"
-                    };
-                    options.AdditionalFormDataParams.Add(param);
+                        var param = new FormDataParam()
+                        {
+                            Name = "screenshot",
+                            Content = new ByteArrayContent(bytes),
+                            FileName = "screenshot.png"
+                        };
+                        options.AdditionalFormDataParams.Add(param);
+                    }
                 }
             }
 
@@ -363,6 +372,8 @@ namespace BugSplatUnity.Runtime.Reporter
                 Debug.LogException(new Exception("Could not delete temp files", ex));
             }
         }
+
+        internal Func<bool> isBatchMode = () => Application.isBatchMode;
 
         private byte[] CaptureInMemoryPngScreenshot()
         {

--- a/Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs
+++ b/Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs
@@ -192,5 +192,33 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 
             Assert.IsTrue(invoked);
         }
+
+        [UnityTest]
+        public IEnumerator Post_WhenCaptureScreenshotsAndBatchMode_ShouldPostWithoutScreenshot()
+        {
+            var exception = new Exception("BugSplat rocks!");
+            var clientSettings = new WebGLClientSettingsRepository
+            {
+                CaptureScreenshots = true,
+                ShouldPostException = (ex) => true
+            };
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                Content = new StringContent("{}")
+            };
+            var fakeExceptionClient = new FakeDotNetExceptionClient(httpResponseMessage);
+            var sut = new DotNetStandardExceptionReporter(clientSettings, fakeExceptionClient)
+            {
+                reportUploadGuardService = new FakeTrueReportUploadGuardService(),
+                isBatchMode = () => true
+            };
+
+            var completed = new Task<bool>(() => true);
+            yield return sut.Post(exception, callback: (_) => completed.Start());
+            yield return completed.AsCoroutine();
+
+            Assert.IsNotEmpty(fakeExceptionClient.Calls);
+            Assert.IsEmpty(fakeExceptionClient.Calls[0].Options.AdditionalFormDataParams);
+        }
     }
 }


### PR DESCRIPTION
Closes #164

## Problem

`DotNetStandardExceptionReporter.Post` yields `new WaitForEndOfFrame()` before capturing the screenshot. On a dedicated server or any `-batchmode` run there is no render loop, so that yield never resumes. The coroutine stops right there, before `exceptionClient.Post` is ever reached, so the report is never uploaded and the callback never fires. This is silent data loss, not just a missing screenshot.

## Fix

Skip the capture entirely when `Application.isBatchMode`, and log why. Everything downstream (attachments, upload, callback) runs as normal.

The check goes through an internal `Func<bool> isBatchMode` seam (same pattern as the existing `reportUploadGuardService` seam) so the branch is deterministically reachable from a test whether or not the test runner itself is batched. It is declared next to the screenshot helper instead of with the other fields to keep the whole change inside the screenshot block — two other fixes (#160, #163) are in flight on this file and this keeps the three diffs disjoint.

## Editor variant: intentionally out of scope

The same wedge can happen in the editor when the Game view is not rendering (hidden/undocked Game view, editor test runs without a Game view). It is not addressed here, deliberately rather than by oversight:

- `Application.isBatchMode` already covers the editor when it is launched with `-batchmode` (including this repo's CI test runner), so the CI path is safe.
- Catching the remaining editor cases needs either editor-only APIs to ask whether the Game view is actually rendering, or a watchdog that races `WaitForEndOfFrame` against a frame/time budget. Both restructure the coroutine well beyond the scope of this fix, and a watchdog is the more honest general answer since it would also cover headless-graphics players.

Flagging it explicitly because a hung report coroutine is silent data loss: the editor case is developer-facing and transient, whereas the batch-mode case affects shipped dedicated servers, which is why only the latter is fixed here.

## Test

`Post_WhenCaptureScreenshotsAndBatchMode_ShouldPostWithoutScreenshot` in `Tests/Runtime/Reporter/DotNetStandardExceptionReporterTests.cs` sets `CaptureScreenshots = true` with the batch-mode seam forced true and asserts that the report still reaches the client with no screenshot form-data param. Without the fix, that test hangs on `WaitForEndOfFrame` in any non-rendering runner instead of reaching the assertions.

## Verification

Compiled `Runtime/**` + `Tests/Runtime/**` against the Unity 6000.5.6f1 managed assemblies with `dotnet build`: build succeeded, 0 errors, 2 pre-existing unrelated `CS0649` warnings in `Runtime/BugSplat.cs`. The new `[UnityTest]` was not executed — running it requires the Unity test runner, which is not available in this environment; it will run in the Tests workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
