### PR TITLE
fix!: default CapturePlayerLog to true on both construction paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The following API methods are available to help you customize BugSplat to fit yo
 
 ### Player.log and privacy
 
-`CapturePlayerLog` is **enabled by default** on both construction paths — a new `BugSplatOptions` asset and a `BugSplat` created in code both start with it on — because `Player.log` is the most useful attachment on a crash report. Be aware that Unity writes it under the user's profile directory on every desktop platform, and it records file system paths that contain the operating system username. If you would rather not collect that, uncheck **Capture Player Log** on your options asset, or set the property in code:
+`CapturePlayerLog` is **enabled by default** on both construction paths — a new `BugSplatOptions` asset and a `BugSplat` created in code both start with it on — because `Player.log` is the most useful attachment on a crash report. WebGL is the exception: the platform has no `Player.log`, so a `BugSplat` created in code there defaults to off and the setting has no effect. Be aware that Unity writes it under the user's profile directory on every desktop platform, and it records file system paths that contain the operating system username. If you would rather not collect that, uncheck **Capture Player Log** on your options asset, or set the property in code:
 
 ```cs
 bugsplat.CapturePlayerLog = false;

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ The following API methods are available to help you customize BugSplat to fit yo
 | Notes | A default general purpose field that can be overridden by call to post |
 | User | A default user that can be overridden by call to Post |
 | CaptureEditorLog| Should BugSplat upload Editor.log when Post is called|
-| CapturePlayerLog| Should BugSplat upload Player.log when Post is called |
+| CapturePlayerLog| Should BugSplat upload Player.log when Post is called. Enabled by default — see [Player.log and privacy](#playerlog-and-privacy) |
 | CaptureScreenshots | Should BugSplat a screenshot and upload it when Post is called |
 | PostExceptionsInEditor | Should BugSplat upload exceptions when in editor |
 | PersistentDataFileAttachmentPaths |  Paths to files (relative to Application.persistentDataPath) to upload with each report |
@@ -430,6 +430,16 @@ The following API methods are available to help you customize BugSplat to fit yo
 | UseNativeCrashReportingForWindows | Use native crash reporting library (bugsplat-windows) for Windows builds. Works with both Mono and IL2CPP |
 | WindowsShowCrashDialog | Show the BugSplat crash dialog when a native crash occurs on Windows (default). When disabled, crash reports are sent silently |
 | WindowsHangDetectionTimeoutMs | Native hang detection timeout in milliseconds for Windows. 0 (default) disables hang detection |
+
+### Player.log and privacy
+
+`CapturePlayerLog` is **enabled by default** on both construction paths — a new `BugSplatOptions` asset and a `BugSplat` created in code both start with it on — because `Player.log` is the most useful attachment on a crash report. Be aware that Unity writes it under the user's profile directory on every desktop platform, and it records file system paths that contain the operating system username. If you would rather not collect that, uncheck **Capture Player Log** on your options asset, or set the property in code:
+
+```cs
+bugsplat.CapturePlayerLog = false;
+```
+
+> **Upgrading from 4.x:** `BugSplatOptions` assets created before 5.0.0 keep whatever value is already serialized in the asset file; only newly created assets pick up the new default. Check the field on your existing asset if you want the new behavior.
 
 ### BugSplat Environment Variables
 

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -46,7 +46,7 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Upload Editor.log when Post is called")]
 		public bool CaptureEditorLog;
 
-		[Tooltip("Upload Player.log when Post is called (default). Player.log paths contain the OS username - uncheck to opt out.")]
+		[Tooltip("Upload Player.log when Post is called (default). Player.log paths contain the OS username - uncheck to opt out. Not available on WebGL.")]
 		public bool CapturePlayerLog = true;
 
         [Tooltip("Maximum size of the log files to upload in MB. Defaults to 10MB if not set.")]

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -46,8 +46,8 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Upload Editor.log when Post is called")]
 		public bool CaptureEditorLog;
 
-		[Tooltip("Upload Player.log when Post is called")]
-		public bool CapturePlayerLog;
+		[Tooltip("Upload Player.log when Post is called (default). Player.log paths contain the OS username - uncheck to opt out.")]
+		public bool CapturePlayerLog = true;
 
         [Tooltip("Maximum size of the log files to upload in MB. Defaults to 10MB if not set.")]
 		public int LogFileMaxSizeMB = 10;

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
@@ -35,7 +35,7 @@ namespace BugSplatUnity.RuntimeTests
 			options.Notes = "notes";
 			options.User = "fred";
 			options.CaptureEditorLog = true;
-			options.CapturePlayerLog = true;
+			options.CapturePlayerLog = false;
 			options.CaptureScreenshots = true;
 			options.LogFileMaxSizeMB = 42;
 			options.PostExceptionsInEditor = false;
@@ -48,7 +48,7 @@ namespace BugSplatUnity.RuntimeTests
 			Assert.AreEqual("notes", sut.Notes, nameof(options.Notes));
 			Assert.AreEqual("fred", sut.User, nameof(options.User));
 			Assert.True(sut.CaptureEditorLog, nameof(options.CaptureEditorLog));
-			Assert.True(sut.CapturePlayerLog, nameof(options.CapturePlayerLog));
+			Assert.False(sut.CapturePlayerLog, nameof(options.CapturePlayerLog));
 			Assert.True(sut.CaptureScreenshots, nameof(options.CaptureScreenshots));
 			Assert.AreEqual(42, sut.LogFileMaxSizeMB, nameof(options.LogFileMaxSizeMB));
 			Assert.False(sut.PostExceptionsInEditor, nameof(options.PostExceptionsInEditor));
@@ -147,6 +147,22 @@ namespace BugSplatUnity.RuntimeTests
 			var sut = BugSplat.CreateFromOptions(options);
 
 			Assert.IsEmpty(sut.Attachments);
+		}
+
+		// A default that differs by construction path is two privacy postures for one setting.
+		// WebGL has no Player.log to capture at all, so its repository default is excluded.
+		[Test]
+		public void CapturePlayerLog_ShouldDefaultToEnabledOnEveryConstructionPath()
+		{
+			var fromOptions = BugSplat.CreateFromOptions(options);
+
+			Assert.True(options.CapturePlayerLog, "BugSplatOptions field default");
+			Assert.True(fromOptions.CapturePlayerLog, "client created from options");
+#if !UNITY_WEBGL
+			var fromCode = new BugSplat("database", "application", "version", false, false);
+
+			Assert.True(fromCode.CapturePlayerLog, "client created in code");
+#endif
 		}
 	}
 }

--- a/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
+++ b/Tests/Runtime/BugSplatCreateFromOptionsTests.cs
@@ -150,19 +150,24 @@ namespace BugSplatUnity.RuntimeTests
 		}
 
 		// A default that differs by construction path is two privacy postures for one setting.
-		// WebGL has no Player.log to capture at all, so its repository default is excluded.
 		[Test]
-		public void CapturePlayerLog_ShouldDefaultToEnabledOnEveryConstructionPath()
+		public void CapturePlayerLog_ShouldDefaultToEnabledWhenCreatedFromOptions()
 		{
 			var fromOptions = BugSplat.CreateFromOptions(options);
 
 			Assert.True(options.CapturePlayerLog, "BugSplatOptions field default");
 			Assert.True(fromOptions.CapturePlayerLog, "client created from options");
+		}
+
 #if !UNITY_WEBGL
+		// WebGL is excluded: it has no Player.log, so its repository defaults to off.
+		[Test]
+		public void CapturePlayerLog_ShouldDefaultToEnabledWhenConstructedInCode()
+		{
 			var fromCode = new BugSplat("database", "application", "version", false, false);
 
 			Assert.True(fromCode.CapturePlayerLog, "client created in code");
-#endif
 		}
+#endif
 	}
 }


### PR DESCRIPTION
Closes #154

## What was wrong

`CapturePlayerLog` had two defaults, and which one you got depended on how the client was constructed:

| Construction path | Default before this PR |
| --- | --- |
| `new BugSplat(...)` in code (`Runtime/Settings/DotNetStandardClientSettingsRepository.cs:24`) | `true` |
| `BugSplat.CreateFromOptions(asset)` (`Runtime/Client/BugSplatOptions.cs:50`, C# field default) | `false` |

Verified on `origin/main` (`f6adbf4`): the repository property is initialized `= true`, the serialized field carried no initializer and therefore landed on C#'s `false`, and `CreateFromOptions` copies the field straight through (`Runtime/BugSplat.cs:392`). Same setting, two privacy postures.

## The default chosen: enabled (`true`)

`Player.log` costs some privacy — Unity writes it under the user's profile directory on every desktop platform and it records paths containing the OS username — but four things point the same way:

1. **It is the highest-value attachment on a report.** A stack trace without the surrounding log is materially harder to act on.
2. **The SDK already behaves as though enabled were the default.** The native Windows path attaches `Player.log` unconditionally at init, the shipped sample asset has `CapturePlayerLog: 1`, and the README's example shows `bugsplat.CapturePlayerLog = false;` — an opt-*out*, which only reads correctly if the default is on.
3. **Choosing `false` would have made #152 a silent regression.** That issue makes the native Windows path honor this flag; with a disabled default, it would have quietly stripped `Player.log` from every native Windows report shipped with default settings.
4. **The privacy cost is now documented rather than implicit**, with the opt-out spelled out in both the Inspector tooltip and the README.

Enabled is also the strictly more conservative migration for the majority path — the one that was already `true`.

## Breaking change

**Newly created `BugSplatOptions` assets now upload `Player.log` by default.** Anyone who relied on a fresh asset shipping with the capture off will start attaching `Player.log` unless they uncheck **Capture Player Log**. The code-constructed path is unchanged (it was already `true`).

One nuance worth knowing: Unity serializes the field, so **existing** assets keep whatever value is already written in their `.asset` file — an asset authored before this change with `CapturePlayerLog: 0` stays disabled. Only newly created assets pick up the new default. That is called out in the README under "Upgrading from 4.x".

5.0.0 is unreleased, so this lands inside the breaking window.

## Scope

- `Runtime/Client/BugSplatOptions.cs` — field initializer + tooltip.
- `Runtime/Settings/DotNetStandardClientSettingsRepository.cs` — **untouched**; it already defaulted `true`, which is the value this PR standardizes on.
- `Runtime/Settings/WebGLClientSettingsRepository.cs` — **untouched**. Its `false` reflects an unimplemented capability (`WebGLReporter` logs "not implemented on this platform"), not a privacy posture. Note that `CreateFromOptions` still copies the option value in on WebGL, so the asset default reaches that path regardless.
- Native attachment logic — **untouched**, per #152.
- `PostExceptionsInEditor` — **untouched**, per #153.

## Tests

`Tests/Runtime/BugSplatCreateFromOptionsTests.cs`:

- New `CapturePlayerLog_ShouldDefaultToEnabledOnEveryConstructionPath` asserts the asset field default, the value on a client built from options, and (outside WebGL) the value on a code-constructed client — the invariant the issue is about.
- `CreateFromOptions_ShouldCopyEveryConfiguredValue` now sets `CapturePlayerLog = false` and asserts `False`. That test's stated contract is that every value is set *away* from its default; leaving it at `true` would have made the assertion pass whether or not the mapping existed.

## Verification

Unity was not run. Both assemblies were compiled offline against the Unity 6000.5.6f1 managed DLLs plus `BugSplatDotNetStandard.dll` (`Runtime/**` + `Tests/Runtime/**`, `dotnet build`) — clean, twice: once with no extra defines and once with `UNITY_WEBGL` defined, so both sides of the new test's `#if` were compiled. **No tests were executed**, and no editor/player behavior (Inspector default on a newly created asset, actual attachment at post time) was observed on a device. CI runs the suite on four build targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
