### PR TITLE
docs: add CHANGELOG.md and package manifest URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.0.0] - Unreleased
+
+Upgrading from 4.x? See [Migrating from 4.x](README.md#migrating-from-4x).
+
+### Added
+
+- **Native Windows crash reporting** via [bugsplat-windows](https://github.com/BugSplat-Git/bugsplat-windows). Unity P/Invokes the SDK's `BugSplat_*` C API exports from `BugSplat.dll`, so native crashes are captured with **both the Mono and IL2CPP** scripting backends, on x86 (32-bit), x64, and ARM64. Enable it with `BugSplatOptions.UseNativeCrashReportingForWindows`. Binaries come from the official signed bugsplat-windows v8.1.0 release.
+- `BugSplatOptions.WindowsShowCrashDialog` — show the BugSplat crash dialog when a native crash occurs on Windows. Defaults to `true`; disable it to upload silently.
+- `BugSplatOptions.WindowsHangDetectionTimeoutMs` — out-of-process hang detection for Windows. Defaults to `0` (disabled). When a hang is detected, BugSplat uploads a hang report and terminates the process, so choose a timeout longer than your longest expected frame.
+- **Windows Error Reporting coverage** for fail-fast terminations — stack buffer overrun (`0xC0000409`), heap corruption (`0xC0000374`), and `__fastfail` — which bypass every in-process exception filter. Capture requires an `HKLM\...\RuntimeExceptionHelperModules` value naming `BugSplatWer.dll`:
+  - `BugSplat.WindowsWerEnabled` reports whether the handler actually registered, and init logs what is lost and how to fix it when it hasn't (a warning in development builds, informational otherwise).
+  - **BugSplat > Windows > Register WER Handler**, **Unregister WER Handler**, and **Check WER Handler Registration** write and verify that value elevated for a built player, in both registry views.
+- Unsent native Windows crash reports are uploaded automatically at startup; init also attaches `Player.log` and syncs attributes, user, email, key, description, and notes to the native reporter.
+- **Capture of unhandled exceptions thrown on background threads.** Unity only raises `logMessageReceived` for main-thread logs, so these were previously written to the player log and never reported. Background exceptions are buffered in a bounded (64-slot) thread-safe queue and posted from the main thread on the next frame, with main-thread logs rejected by thread id so nothing reports twice. On by default; opt out via **Capture Exceptions On Background Threads** on `BugSplatManager`.
+- Editor menu for symbol upload credentials: **BugSplat > Symbol Upload > Set Credentials**, **Clear Credentials**, and **Check Credentials**.
+- `Description`, `Email`, `Key`, `Notes`, and `User` gained getters — they were previously set-only.
+- Continuous integration (`.github/workflows/tests.yml`): the test suite runs on StandaloneLinux64, StandaloneWindows64, StandaloneOSX, and WebGL, plus player-script compile checks for iOS and Android that cover the code behind `!UNITY_EDITOR`, which tests cannot link against.
+- Test coverage for the `CreateFromOptions` mapping, `CopyLogTailToTempFile`, the background log message queue, and `BugSplatManager` wiring.
+- The `my-unity-crasher` sample is now a platform-aware crash scenario menu, grouped by the mechanism expected to capture each row (`MANAGED`, `NATIVE`, `FAIL-FAST`, `HANG`, `FEEDBACK`), with sections compiled per build target. Native rows are inert in the editor, and `FAIL-FAST` rows grey out when the WER handler isn't registered. No crasher DLL is shipped — every trigger is C# plus P/Invokes into system DLLs.
+
+### Changed
+
+- **Breaking:** `BugSplatOptions.Attributes` is now `List<BugSplatAttribute>` instead of `Dictionary<string, string>`. Unity cannot serialize a dictionary, so the field could never be authored in the inspector. Unity drops the old serialized value silently when a 4.x options asset is opened.
+- **Breaking:** the symbol upload environment variables are renamed from `BUGSPLAT_CLIENT_ID`/`BUGSPLAT_CLIENT_SECRET` to `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET`, the names the `symbol-upload` CLI already reads. The old names are no longer read.
+- **Breaking for coroutines that yield on `Post`:** report uploads are now awaited. `yield return Task.Run(...)` waits a single frame rather than for the task, so `yield return bugsplat.Post(ex); Application.Quit();` lost reports nondeterministically. Those coroutines now genuinely wait for the upload.
+- Response parsing and callbacks run on the main thread. They previously ran on a threadpool thread, so any callback touching a Unity API threw.
+- Symbol upload credentials are machine-local and per database, resolved from the environment first and then from `~/.bugsplat/credentials/<database>.sh`. The generated Xcode build phase sources that path from `$HOME`, so nothing project-local holds a secret.
+- `Post(FileInfo)` works on all platforms for posting your own minidump files. It was previously implemented only on Windows and WSA.
+- Editor post-build copies `BugSplatMonitor.exe`, `BugSplatRc.dll`, and `BugSplatWer.dll` next to the built Windows player, with the architecture detected from the executable's PE header, and copies `LineNumberMappings.json` for IL2CPP builds when present.
+- Log messages are filtered through the reportable-message check before a coroutine is allocated. Every log message of every type previously allocated one, with the `LogType` filter running inside it.
+
+### Removed
+
+- **Breaking:** `WindowsReporter` and `INativeCrashReporter`. Unity's `CrashReporting.crashReportFolder` minidumps are no longer read or uploaded — native Windows crashes are captured by bugsplat-windows instead.
+- **Breaking:** `PostAllCrashes`, `PostCrash`, and `PostMostRecentCrash`. Unsent native crash reports upload automatically at startup, so there is nothing to call at launch. Delete any calls to these methods.
+- **Breaking:** `BugSplatOptions.SymbolUploadClientId` and `BugSplatOptions.SymbolUploadClientSecret`. Set credentials from **BugSplat > Symbol Upload > Set Credentials**, or with the environment variables in CI.
+- Sample-only, no package API affected: the `ErrorGenerator`, `BugSplatLayoutButtons`, and `PlatformDependentObject` scripts and the `Button_ForceCrash` prefab, all superseded by the scenario menu.
+
+### Fixed
+
+- Android native crash reporting was never actually enabled — the Android init branch never set the flag every native setter guards on, so all of them silently no-oped, including the attribute-sync callback. Runtime attributes, user, email, key, and notes now reach the native reporter.
+- `SetNativeKey` had no iOS or macOS branch, so `Key` never reached Apple native reports. Both now assign bugsplat-apple's `appKey` property directly.
+- `BugSplatOptions.Attributes` were never read by `CreateFromOptions`, so attributes authored on an options asset never reached a report.
+- The test assemblies did not compile on any build target: `IClientSettingsRepository.LogFileMaxSizeMB` sat behind `#if !UNITY_WEBGL` while being used unconditionally, and `WebGLClientSettingsRepository` sat behind `#if UNITY_WEBGL` while three test files referenced it unguarded.
+- `CopyLogTailToTempFile`'s null guard dereferenced the argument it was checking.
+
+### Security
+
+- Symbol upload credentials no longer leave the developer's machine. They previously had three exits: inlined into the `/bin/sh` build phase inside `project.pbxproj`, serialized onto the `BugSplatOptions` asset and therefore into version control and shipped builds, and passed as a `--clientSecret` command-line argument visible in process listings.
+- **An iOS build phase generated before 5.0.0 contains your Client ID and Secret in plain text — rotate them.** Projects exported with Append, or checked into version control, keep the old "Upload dSYM files to BugSplat" phase; delete it and build again, or re-export with Replace.
+
+## [4.1.0] - 2026-05-22
+
+### Added
+
+- ANR reporting on Android and hang detection on iOS ([#122](https://github.com/BugSplat-Git/bugsplat-unity/pull/122)).
+
+## [4.0.1] - 2026-05-22
+
+### Added
+
+- Native macOS crash reporting via bugsplat-apple ([#117](https://github.com/BugSplat-Git/bugsplat-unity/pull/117)).
+
+### Fixed
+
+- App Store and Google Play compatible SDKs ([#116](https://github.com/BugSplat-Git/bugsplat-unity/pull/116)).
+- Android native crash attributes are set after init ([#118](https://github.com/BugSplat-Git/bugsplat-unity/pull/118)).
+
+## [4.0.0] - 2026-03-23
+
+### Added
+
+- `PostFeedback` API for user feedback submission ([#114](https://github.com/BugSplat-Git/bugsplat-unity/pull/114)).
+
+### Changed
+
+- **Breaking:** the minimum supported Unity version is raised to 6000.0 (Unity 6), from 2021.3.
+
+### Fixed
+
+- Log truncation on macOS, Linux, and WSA ([#113](https://github.com/BugSplat-Git/bugsplat-unity/pull/113)).
+- README typos ([#104](https://github.com/BugSplat-Git/bugsplat-unity/pull/104)).
+
+## Earlier releases
+
+Releases before 4.0.0 predate this changelog. See the [GitHub releases page](https://github.com/BugSplat-Git/bugsplat-unity/releases) for their notes.
+
+[5.0.0]: https://github.com/BugSplat-Git/bugsplat-unity/compare/v4.1.0...main
+[4.1.0]: https://github.com/BugSplat-Git/bugsplat-unity/compare/v4.0.1...v4.1.0
+[4.0.1]: https://github.com/BugSplat-Git/bugsplat-unity/compare/v4.0.0...v4.0.1
+[4.0.0]: https://github.com/BugSplat-Git/bugsplat-unity/compare/v3.2.2...v4.0.0

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0cd02b624e3341ad9b4ebdbd829b29fc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "displayName": "BugSplat",
     "description": "Unity crash reporting powered by BugSplat",
     "unity": "6000.0",
+    "documentationUrl": "https://docs.bugsplat.com/integrations/game-development/unity",
+    "changelogUrl": "https://github.com/BugSplat-Git/bugsplat-unity/blob/main/CHANGELOG.md",
+    "licensesUrl": "https://github.com/BugSplat-Git/bugsplat-unity/blob/main/LICENSE.md",
     "keywords": [
         "bugsplat",
         "crash",


### PR DESCRIPTION
Closes #156

Adds a keepachangelog-format `CHANGELOG.md` at the package root and fills in the three manifest URL fields the Package Manager UI reads.

## Manifest fields

`documentationUrl`, `changelogUrl`, and `licensesUrl` are documented optional properties of the Unity package manifest — confirmed against [Package manifest](https://docs.unity3d.com/Manual/upm-manifestPkg.html), which describes each as a "custom location for this package's ... specified as a URL". The Package Manager falls back to the in-package `CHANGELOG.md`, `Documentation~`, and `LICENSE.md` when the URL is unreachable, so shipping the file *and* the URL is the intended combination, not a duplication.

- `documentationUrl` → https://docs.bugsplat.com/integrations/game-development/unity (verified live; the older `introduction/getting-started/integrations/...` path 404s)
- `changelogUrl` → the new `CHANGELOG.md` on `main`
- `licensesUrl` → the existing `LICENSE.md` on `main`

`package.json` parses cleanly under both `python -m json.tool` and `node -e "require('./package.json')"`. A `CHANGELOG.md.meta` is included so the package ships a stable GUID for the asset, matching the existing `README.md.meta`/`LICENSE.md.meta`.

## Why "Unreleased" rather than a date

The 5.0.0 section is headed `## [5.0.0] - Unreleased`. Keep a Changelog's guidance is an `Unreleased` section at the top, but the version here is not unknown — `package.json` already says `5.0.0` and the tag simply hasn't been cut. Naming the version keeps the link reference and the compare URL usable now, while `- Unreleased` in the date slot stops it reading as shipped. At release, that one word becomes the date; nothing else moves. Per the task, no version bump is included.

## Sourcing

The 5.0.0 entry is derived from #123 and then **verified against the code**, not transcribed. Two items in the issue's summary did not survive that check:

- **`PostAllCrashes`/`PostCrash`/`PostMostRecentCrash` were removed, not marked `[Obsolete]`.** There is no `[Obsolete]` attribute anywhere in the tree, the methods are gone from `Runtime/BugSplat.cs` (they exist at `v4.1.0:Runtime/BugSplat.cs:395,410,425`), and `README.md:393` already says "have been removed". Listed under **Removed**.
- **The Unity 6000.0 minimum is not a 5.0.0 change.** `v3.2.2` declared `2021.3` and `v4.0.0` declared `6000.0`, and the v4.0.0 release notes call it out as that release's breaking change. Recorded under 4.0.0 instead.

Everything else was confirmed: `WindowsReporter.cs`/`INativeCrashReporter.cs` deleted, `Attributes` changed from `Dictionary<string, string>` to `List<BugSplatAttribute>` with the new `[Serializable]` type, `SymbolUploadClientId`/`SymbolUploadClientSecret` deleted from the options asset, `SYMBOL_UPLOAD_CLIENT_ID`/`SYMBOL_UPLOAD_CLIENT_SECRET` as the env var names in `BugSplatSymbolUploadCredentials.cs`, the `~/.bugsplat/credentials/<database>.sh` path shape, the three sample scripts and the `Button_ForceCrash` prefab deleted, `Post(FileInfo)` freed from its `#if UNITY_STANDALONE_WIN || UNITY_WSA` guard, `WindowsWerEnabled`, the WER and symbol-upload menu items, and `.github/workflows/tests.yml`.

One correction from the code: **`WindowsShowCrashDialog` defaults to `true`** (`BugSplatOptions.cs`), so the changelog says the dialog shows by default and you disable it to upload silently — not the other way round.

Earlier entries cover 4.1.0, 4.0.1, and 4.0.0, sourced from the GitHub release notes and tag dates. **Anything before 4.0.0 is deliberately absent** — those releases carry no notes worth transcribing and reconstructing them from commit subjects alone would be invention. The file points at the releases page for those instead.

## Not included

- No version bump, no tag, no release.
- No README link to the changelog — out of scope for this issue.
- The 5.0.0 entry documents behaviour as merged. The verification checklist in #123 (ARM64/x86 runtime checks, offline retry, real uploaded reports for several of the merged sub-PRs) is still open and is tracked there, not here.
