### PR TITLE
fix: skip null log-tail attachments instead of propagating them

### DIFF
--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -92,9 +92,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(editorLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(editorLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -113,9 +111,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(editorLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(editorLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -134,9 +130,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(editorLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(editorLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -163,9 +157,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(playerLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(playerLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -184,9 +176,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(playerLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(playerLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -205,9 +195,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(playerLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(playerLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -226,9 +214,7 @@ namespace BugSplatUnity.Runtime.Reporter
                 {
                     try
                     {
-                        var tempFile = CopyLogTailToTempFile(playerLogFileInfo, clientSettings.LogFileMaxSizeMB);
-                        options.AdditionalAttachments.Add(tempFile);
-                        tempFiles.Add(tempFile);
+                        AddLogTailAttachment(playerLogFileInfo, options, tempFiles);
                     }
                     catch (Exception ex)
                     {
@@ -306,6 +292,19 @@ namespace BugSplatUnity.Runtime.Reporter
                     Message = $"BugSplat upload failed with exception: {ex}",
                 });
             }
+        }
+
+        internal void AddLogTailAttachment(FileInfo logFileInfo, IReportPostOptions options, List<FileInfo> tempFiles)
+        {
+            var tempFile = CopyLogTailToTempFile(logFileInfo, clientSettings.LogFileMaxSizeMB);
+
+            if (tempFile == null)
+            {
+                return;
+            }
+
+            options.AdditionalAttachments.Add(tempFile);
+            tempFiles.Add(tempFile);
         }
 
         // Copy to a temp file to avoid sharing exception

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
@@ -17,6 +17,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 
 		DotNetStandardExceptionReporter sut;
 		string workingDirectory;
+		List<string> tempCopyDirectories;
 
 		[SetUp]
 		public void SetUp()
@@ -27,6 +28,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 
 			workingDirectory = Path.Combine(Path.GetTempPath(), "bugsplat-log-tail-tests", Path.GetRandomFileName());
 			Directory.CreateDirectory(workingDirectory);
+			tempCopyDirectories = new List<string>();
 		}
 
 		[TearDown]
@@ -36,6 +38,26 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			{
 				Directory.Delete(workingDirectory, true);
 			}
+
+			foreach (var tempCopyDirectory in tempCopyDirectories)
+			{
+				if (Directory.Exists(tempCopyDirectory))
+				{
+					Directory.Delete(tempCopyDirectory, true);
+				}
+			}
+		}
+
+		// CopyLogTailToTempFile writes each copy to its own generated directory
+		// that nothing cleans up in tests, so every non-null result must be
+		// tracked for TearDown.
+		FileInfo TrackTempCopy(FileInfo tempCopy)
+		{
+			if (tempCopy != null)
+			{
+				tempCopyDirectories.Add(tempCopy.DirectoryName);
+			}
+			return tempCopy;
 		}
 
 		FileInfo WriteLog(string name, byte[] contents)
@@ -62,7 +84,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			var contents = Encoding.UTF8.GetBytes("a small log file");
 			var log = WriteLog("Player.log", contents);
 
-			var result = sut.CopyLogTailToTempFile(log, 1);
+			var result = TrackTempCopy(sut.CopyLogTailToTempFile(log, 1));
 
 			Assert.NotNull(result);
 			Assert.AreEqual(contents.Length, result.Length);
@@ -75,7 +97,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			var contents = Repeating(2 * OneMegabyte + 4096);
 			var log = WriteLog("Player.log", contents);
 
-			var result = sut.CopyLogTailToTempFile(log, 1);
+			var result = TrackTempCopy(sut.CopyLogTailToTempFile(log, 1));
 
 			Assert.NotNull(result);
 			Assert.AreEqual(OneMegabyte, result.Length, "should be truncated to exactly the max size");
@@ -90,7 +112,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 		{
 			var log = WriteLog("Editor.log", Encoding.UTF8.GetBytes("contents"));
 
-			var result = sut.CopyLogTailToTempFile(log, 1);
+			var result = TrackTempCopy(sut.CopyLogTailToTempFile(log, 1));
 
 			Assert.AreEqual("Editor.log", result.Name);
 		}
@@ -101,7 +123,7 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			var contents = Repeating(2 * OneMegabyte);
 			var log = WriteLog("Player.log", contents);
 
-			sut.CopyLogTailToTempFile(log, 1);
+			TrackTempCopy(sut.CopyLogTailToTempFile(log, 1));
 
 			Assert.AreEqual(contents.Length, new FileInfo(log.FullName).Length);
 		}
@@ -133,6 +155,10 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			var tempFiles = new List<FileInfo>();
 
 			sut.AddLogTailAttachment(log, options, tempFiles);
+			foreach (var tempFile in tempFiles)
+			{
+				TrackTempCopy(tempFile);
+			}
 
 			Assert.AreEqual(1, options.AdditionalAttachments.Count);
 			Assert.AreEqual(1, tempFiles.Count);

--- a/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
+++ b/Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs
@@ -2,6 +2,7 @@ using BugSplatUnity.Runtime.Reporter;
 using BugSplatUnity.Runtime.Settings;
 using BugSplatUnity.RuntimeTests.Reporter.Fakes;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -121,6 +122,52 @@ namespace BugSplatUnity.RuntimeTests.Reporter
 			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
 
 			Assert.Null(sut.CopyLogTailToTempFile(null, 1));
+		}
+
+		[Test]
+		public void AddLogTailAttachment_WhenFileExists_ShouldAddTempFileToAttachmentsAndTempFiles()
+		{
+			var contents = Encoding.UTF8.GetBytes("a small log file");
+			var log = WriteLog("Player.log", contents);
+			var options = new ReportPostOptions();
+			var tempFiles = new List<FileInfo>();
+
+			sut.AddLogTailAttachment(log, options, tempFiles);
+
+			Assert.AreEqual(1, options.AdditionalAttachments.Count);
+			Assert.AreEqual(1, tempFiles.Count);
+			Assert.AreSame(options.AdditionalAttachments[0], tempFiles[0]);
+			Assert.AreEqual("Player.log", options.AdditionalAttachments[0].Name);
+			CollectionAssert.AreEqual(contents, File.ReadAllBytes(options.AdditionalAttachments[0].FullName));
+		}
+
+		[Test]
+		public void AddLogTailAttachment_WhenFileDoesNotExist_ShouldNotAddNullToAttachmentsOrTempFiles()
+		{
+			var missing = new FileInfo(Path.Combine(workingDirectory, "missing.log"));
+			var options = new ReportPostOptions();
+			var tempFiles = new List<FileInfo>();
+
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			sut.AddLogTailAttachment(missing, options, tempFiles);
+
+			Assert.IsEmpty(options.AdditionalAttachments);
+			Assert.IsEmpty(tempFiles);
+		}
+
+		[Test]
+		public void AddLogTailAttachment_WhenFileInfoIsNull_ShouldNotAddNullToAttachmentsOrTempFiles()
+		{
+			var options = new ReportPostOptions();
+			var tempFiles = new List<FileInfo>();
+
+			LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("does not exist"));
+
+			sut.AddLogTailAttachment(null, options, tempFiles);
+
+			Assert.IsEmpty(options.AdditionalAttachments);
+			Assert.IsEmpty(tempFiles);
 		}
 	}
 }


### PR DESCRIPTION
Closes #160

## Problem

`CopyLogTailToTempFile` returns `null` when the log file is missing or when the copy throws. All **7** call sites in `Runtime/Reporter/DotNetStandardExceptionReporter.cs` (3 editor-log branches: `UNITY_EDITOR_WIN` / `_OSX` / `_LINUX`; 4 player-log branches: `UNITY_STANDALONE_WIN` / `_OSX` / `_LINUX`, `UNITY_WSA`) then did:

```csharp
var tempFile = CopyLogTailToTempFile(logFileInfo, clientSettings.LogFileMaxSizeMB);
options.AdditionalAttachments.Add(tempFile);
tempFiles.Add(tempFile);
```

unconditionally, so a `null` `FileInfo` landed in both the outgoing attachment list and the cleanup list. `DeleteTempFiles` then NRE'd on `tempFile.Exists` inside its own `try`, where the exception is swallowed — which also aborts the loop, leaking every temp file queued after the null one.

## Fix

Guard once in a small `AddLogTailAttachment` helper rather than repeating the same null check 7 times:

```csharp
internal void AddLogTailAttachment(FileInfo logFileInfo, IReportPostOptions options, List<FileInfo> tempFiles)
{
    var tempFile = CopyLogTailToTempFile(logFileInfo, clientSettings.LogFileMaxSizeMB);

    if (tempFile == null)
    {
        return;
    }

    options.AdditionalAttachments.Add(tempFile);
    tempFiles.Add(tempFile);
}
```

**Why a helper over 7 inline null checks:** the 7 blocks were byte-identical apart from the log `FileInfo` variable, so the inline version would have been the same 4 lines copy-pasted 7 times, with 7 chances to drift. The helper also makes the guard directly unit-testable — a null check buried in a platform-gated `#if` branch is not reachable from a test, since only one branch compiles per platform. Net effect on the file is *smaller*: 20 insertions, 21 deletions.

Deliberately **not** changed:

- The surrounding `try` / `catch (Exception ex) { Debug.LogException(...) }` blocks stay exactly as they were. They still cover `Directory.CreateDirectory`, which sits outside `CopyLogTailToTempFile`'s own `catch`. Leaving them untouched also keeps this PR off the lines that #163 (`Debug.LogException` re-entrancy) is editing.
- `DeleteTempFiles` — nulls can no longer reach it, and a defensive check there would only mask a future regression.

## Tests

Extended `Tests/Runtime/Reporter/CopyLogTailToTempFileTests.cs` with 3 tests covering the previously untestable path:

- `AddLogTailAttachment_WhenFileExists_ShouldAddTempFileToAttachmentsAndTempFiles` — happy path; the same `FileInfo` instance lands in both lists, keeps the original name, and has the copied contents.
- `AddLogTailAttachment_WhenFileDoesNotExist_ShouldNotAddNullToAttachmentsOrTempFiles` — the regression this issue is about.
- `AddLogTailAttachment_WhenFileInfoIsNull_ShouldNotAddNullToAttachmentsOrTempFiles`

## Verification

Unity was not run. What was actually done:

1. **Compile check of every platform branch.** Runtime + Tests sources compiled against the Unity 6000.5.6f1 managed assemblies with `dotnet build`, once per platform define set, so all 7 edited call sites were really compiled (each lives in a mutually exclusive `#if`):

   | Defines | Result |
   | --- | --- |
   | *(none)* | 0 errors |
   | `UNITY_EDITOR_WIN;UNITY_STANDALONE_WIN` | 0 errors |
   | `UNITY_EDITOR_OSX;UNITY_STANDALONE_OSX` | 0 errors |
   | `UNITY_EDITOR_LINUX;UNITY_STANDALONE_LINUX` | 0 errors |
   | `UNITY_WSA` | 0 errors |

   Only the 2 pre-existing `CS0649` warnings in `BugSplat.cs` appear; no new warnings.

2. **Test run outside Unity** via `dotnet test` (NUnit 3.14 + NUnit3TestAdapter + Microsoft.NET.Test.Sdk): **5 passed, 4 failed, 9 total**.

   The 5 passes include the new `AddLogTailAttachment_WhenFileExists_...`. The 4 failures are all environmental, not assertion failures — they are exactly the 4 tests that exercise the missing-file path, which calls `UnityEngine.Debug.LogError` and therefore `LogAssert.Expect`:

   - `LogAssert.Expect` → `InvalidOperationException: No log scope is available` (requires the Unity test runner).
   - With `LogAssert` stripped in a scratch copy, they fail one layer deeper on `SecurityException: ECall methods must be packaged into a system module` at `UnityEngine.DebugLogHandler.Internal_Log_Injected` — `Debug.LogError` needs the Unity native runtime.

   **2 of those 4 failures are pre-existing tests this PR does not touch** (`CopyLogTailToTempFile_WhenFileDoesNotExist_ShouldReturnNull`, `CopyLogTailToTempFile_WhenFileInfoIsNull_ShouldReturnNull`), which confirms the cause is the missing Unity runtime rather than anything in this change. All 9 should pass under the Unity Test Runner; that was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
