### PR TITLE
fix!: move public types out of the global namespace

### DIFF
--- a/Editor/BugSplatOptionsEditor.cs
+++ b/Editor/BugSplatOptionsEditor.cs
@@ -2,69 +2,72 @@ using BugSplatUnity.Runtime.Client;
 using UnityEditor;
 using UnityEngine;
 
-[CustomEditor(typeof(BugSplatOptions))]
-public class BugSplatOptionsEditor : Editor
+namespace BugSplatUnity.Editor
 {
-    private const string logoPath = "Packages/com.bugsplat.unity/Editor/EditorResources/logo.png";
-    private const string integrationsURLFormat = "https://app.bugsplat.com/v2/settings/database/integrations{0}";
-    private const string integrationsText = "<color=#040404>A Client ID and Client Secret pair can be generated on the BugSplat <a>Integrations</a> page.</color>";
-    private const string integrationsQueryString = "?database={0}";
-    private const string emptyDatabaseErrorMessage = "Database cannot be null or empty!";
-    private const string credentialsInfoMessage = "Symbol upload credentials are not stored here — they would end up in version control and in your builds. Set them per database via BugSplat > Symbol Upload > Set Credentials, or with the SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET environment variables.";
-
-    private const int integrationsPaddingTop = 5;
-    private const int integrationsPaddingBottom = 5;
-
-    public override void OnInspectorGUI()
+    [CustomEditor(typeof(BugSplatOptions))]
+    public class BugSplatOptionsEditor : UnityEditor.Editor
     {
-        var options = target as BugSplatOptions;
-        var texture = AssetDatabase.LoadAssetAtPath(logoPath, typeof(Texture2D)) as Texture2D;
-        if (texture != null)
+        private const string logoPath = "Packages/com.bugsplat.unity/Editor/EditorResources/logo.png";
+        private const string integrationsURLFormat = "https://app.bugsplat.com/v2/settings/database/integrations{0}";
+        private const string integrationsText = "<color=#040404>A Client ID and Client Secret pair can be generated on the BugSplat <a>Integrations</a> page.</color>";
+        private const string integrationsQueryString = "?database={0}";
+        private const string emptyDatabaseErrorMessage = "Database cannot be null or empty!";
+        private const string credentialsInfoMessage = "Symbol upload credentials are not stored here — they would end up in version control and in your builds. Set them per database via BugSplat > Symbol Upload > Set Credentials, or with the SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET environment variables.";
+
+        private const int integrationsPaddingTop = 5;
+        private const int integrationsPaddingBottom = 5;
+
+        public override void OnInspectorGUI()
         {
-            GUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            GUILayout.Label(texture);
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
+            var options = target as BugSplatOptions;
+            var texture = AssetDatabase.LoadAssetAtPath(logoPath, typeof(Texture2D)) as Texture2D;
+            if (texture != null)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.FlexibleSpace();
+                GUILayout.Label(texture);
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+            }
+
+            var iterator = serializedObject.GetIterator();
+            var traverseChildren = true;
+            while (iterator.NextVisible(traverseChildren))
+            {
+                traverseChildren = false;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty(iterator.name), true);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+
+            if (string.IsNullOrEmpty(options.Database))
+            {
+                EditorGUILayout.HelpBox(emptyDatabaseErrorMessage, MessageType.Error);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(credentialsInfoMessage, MessageType.Info);
+
+            var queryString = !string.IsNullOrEmpty(options.Database)
+                ? string.Format(integrationsQueryString, options.Database)
+                : string.Empty;
+            var integrationsURL = string.Format(integrationsURLFormat, queryString);
+
+            var style = new GUIStyle()
+            {
+                richText = true,
+                wordWrap = true,
+                margin = new RectOffset(0, 0, integrationsPaddingTop, integrationsPaddingBottom)
+            };
+
+            if (GUILayout.Button(integrationsText, style))
+            {
+                Application.OpenURL(integrationsURL);
+            }
+
+            var rect = GUILayoutUtility.GetLastRect();
+            rect.width = style.CalcSize(new GUIContent(integrationsText)).x;
+            EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
         }
-
-        var iterator = serializedObject.GetIterator();
-        var traverseChildren = true;
-        while (iterator.NextVisible(traverseChildren))
-        {
-            traverseChildren = false;
-            EditorGUILayout.PropertyField(serializedObject.FindProperty(iterator.name), true);
-        }
-
-        serializedObject.ApplyModifiedProperties();
-
-        if (string.IsNullOrEmpty(options.Database))
-        {
-            EditorGUILayout.HelpBox(emptyDatabaseErrorMessage, MessageType.Error);
-        }
-
-        EditorGUILayout.Space();
-        EditorGUILayout.HelpBox(credentialsInfoMessage, MessageType.Info);
-
-        var queryString = !string.IsNullOrEmpty(options.Database)
-            ? string.Format(integrationsQueryString, options.Database)
-            : string.Empty;
-        var integrationsURL = string.Format(integrationsURLFormat, queryString);
-
-        var style = new GUIStyle()
-        {
-            richText = true,
-            wordWrap = true,
-            margin = new RectOffset(0, 0, integrationsPaddingTop, integrationsPaddingBottom)
-        };
-
-        if (GUILayout.Button(integrationsText, style))
-        {
-            Application.OpenURL(integrationsURL);
-        }
-
-        var rect = GUILayoutUtility.GetLastRect();
-        rect.width = style.CalcSize(new GUIContent(integrationsText)).x;
-        EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
     }
 }

--- a/Editor/BugSplatSymbolUploadCredentials.cs
+++ b/Editor/BugSplatSymbolUploadCredentials.cs
@@ -2,162 +2,165 @@ using System;
 using System.IO;
 using System.Text.RegularExpressions;
 
-/// <summary>
-/// Resolves symbol upload credentials, which are per-database and machine-local.
-///
-/// They are never stored in the project: an asset carrying them ends up in version control and in
-/// shipped player builds, which is what this replaces. Instead they live in the user's home
-/// directory, one file per BugSplat database, in the shell format the symbol-upload CLI already
-/// understands so the generated Xcode build phase can source the same file directly.
-/// </summary>
-public static class BugSplatSymbolUploadCredentials
+namespace BugSplatUnity.Editor
 {
-	// The names the symbol-upload CLI reads, so nothing has to be remapped on the way down.
-	public const string ClientIdEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_ID";
-	public const string ClientSecretEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_SECRET";
-
-	const string CredentialsDirectoryName = ".bugsplat";
-	const string CredentialsSubdirectoryName = "credentials";
-
 	/// <summary>
-	/// Absolute path to the credentials file for a database. Shared with the generated Xcode build
-	/// phase, which resolves the same path against $HOME.
+	/// Resolves symbol upload credentials, which are per-database and machine-local.
+	///
+	/// They are never stored in the project: an asset carrying them ends up in version control and in
+	/// shipped player builds, which is what this replaces. Instead they live in the user's home
+	/// directory, one file per BugSplat database, in the shell format the symbol-upload CLI already
+	/// understands so the generated Xcode build phase can source the same file directly.
 	/// </summary>
-	public static string GetCredentialsPath(string database)
+	public static class BugSplatSymbolUploadCredentials
 	{
-		var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		return Path.Combine(home, CredentialsDirectoryName, CredentialsSubdirectoryName, $"{SanitizeDatabase(database)}.sh");
-	}
+		// The names the symbol-upload CLI reads, so nothing has to be remapped on the way down.
+		public const string ClientIdEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_ID";
+		public const string ClientSecretEnvironmentVariable = "SYMBOL_UPLOAD_CLIENT_SECRET";
 
-	/// <summary>
-	/// The path the Xcode build phase uses, expressed relative to $HOME so the generated script
-	/// carries no absolute path from the machine that ran the Unity build.
-	/// </summary>
-	public static string GetCredentialsPathRelativeToHome(string database)
-		=> $"{CredentialsDirectoryName}/{CredentialsSubdirectoryName}/{SanitizeDatabase(database)}.sh";
+		const string CredentialsDirectoryName = ".bugsplat";
+		const string CredentialsSubdirectoryName = "credentials";
 
-	/// <summary>
-	/// Resolves credentials for a database: the environment wins, then the credentials file.
-	/// Returns false when neither supplies both values.
-	/// </summary>
-	public static bool TryResolve(string database, out string clientId, out string clientSecret)
-	{
-		clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable);
-		clientSecret = Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable);
-
-		if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+		/// <summary>
+		/// Absolute path to the credentials file for a database. Shared with the generated Xcode build
+		/// phase, which resolves the same path against $HOME.
+		/// </summary>
+		public static string GetCredentialsPath(string database)
 		{
+			var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			return Path.Combine(home, CredentialsDirectoryName, CredentialsSubdirectoryName, $"{SanitizeDatabase(database)}.sh");
+		}
+
+		/// <summary>
+		/// The path the Xcode build phase uses, expressed relative to $HOME so the generated script
+		/// carries no absolute path from the machine that ran the Unity build.
+		/// </summary>
+		public static string GetCredentialsPathRelativeToHome(string database)
+			=> $"{CredentialsDirectoryName}/{CredentialsSubdirectoryName}/{SanitizeDatabase(database)}.sh";
+
+		/// <summary>
+		/// Resolves credentials for a database: the environment wins, then the credentials file.
+		/// Returns false when neither supplies both values.
+		/// </summary>
+		public static bool TryResolve(string database, out string clientId, out string clientSecret)
+		{
+			clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariable);
+			clientSecret = Environment.GetEnvironmentVariable(ClientSecretEnvironmentVariable);
+
+			if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+			{
+				return true;
+			}
+
+			var stored = Read(database);
+			if (string.IsNullOrEmpty(clientId))
+			{
+				clientId = stored.clientId;
+			}
+
+			if (string.IsNullOrEmpty(clientSecret))
+			{
+				clientSecret = stored.clientSecret;
+			}
+
+			return !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret);
+		}
+
+		public static bool Exists(string database) => File.Exists(GetCredentialsPath(database));
+
+		public static (string clientId, string clientSecret) Read(string database)
+		{
+			var path = GetCredentialsPath(database);
+			if (!File.Exists(path))
+			{
+				return (string.Empty, string.Empty);
+			}
+
+			string id = string.Empty, secret = string.Empty;
+			foreach (var line in File.ReadAllLines(path))
+			{
+				var match = Regex.Match(line.Trim(), @"^export\s+(\w+)='(.*)'$");
+				if (!match.Success)
+				{
+					continue;
+				}
+
+				// Undo the POSIX single-quote escaping applied by Write.
+				var value = match.Groups[2].Value.Replace("'\\''", "'");
+				if (match.Groups[1].Value == ClientIdEnvironmentVariable)
+				{
+					id = value;
+				}
+				else if (match.Groups[1].Value == ClientSecretEnvironmentVariable)
+				{
+					secret = value;
+				}
+			}
+
+			return (id, secret);
+		}
+
+		public static void Write(string database, string clientId, string clientSecret)
+		{
+			var path = GetCredentialsPath(database);
+			Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+			File.WriteAllText(
+				path,
+				$"# BugSplat symbol upload credentials for the '{database}' database.\n" +
+				"# Machine-local and not part of any project. Delete this file to revoke it here.\n" +
+				$"export {ClientIdEnvironmentVariable}='{EscapeShellSingleQuoted(clientId)}'\n" +
+				$"export {ClientSecretEnvironmentVariable}='{EscapeShellSingleQuoted(clientSecret)}'\n");
+
+			RestrictToOwner(path);
+		}
+
+		public static bool Clear(string database)
+		{
+			var path = GetCredentialsPath(database);
+			if (!File.Exists(path))
+			{
+				return false;
+			}
+
+			File.Delete(path);
 			return true;
 		}
 
-		var stored = Read(database);
-		if (string.IsNullOrEmpty(clientId))
+		// Database names are subdomains of bugsplat.com, so this should never alter a real one - it is
+		// here so a malformed value cannot escape the credentials directory.
+		static string SanitizeDatabase(string database)
 		{
-			clientId = stored.clientId;
-		}
-
-		if (string.IsNullOrEmpty(clientSecret))
-		{
-			clientSecret = stored.clientSecret;
-		}
-
-		return !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret);
-	}
-
-	public static bool Exists(string database) => File.Exists(GetCredentialsPath(database));
-
-	public static (string clientId, string clientSecret) Read(string database)
-	{
-		var path = GetCredentialsPath(database);
-		if (!File.Exists(path))
-		{
-			return (string.Empty, string.Empty);
-		}
-
-		string id = string.Empty, secret = string.Empty;
-		foreach (var line in File.ReadAllLines(path))
-		{
-			var match = Regex.Match(line.Trim(), @"^export\s+(\w+)='(.*)'$");
-			if (!match.Success)
+			if (string.IsNullOrWhiteSpace(database))
 			{
-				continue;
+				return "unknown";
 			}
 
-			// Undo the POSIX single-quote escaping applied by Write.
-			var value = match.Groups[2].Value.Replace("'\\''", "'");
-			if (match.Groups[1].Value == ClientIdEnvironmentVariable)
+			return Regex.Replace(database.Trim(), @"[^A-Za-z0-9_.-]", "_");
+		}
+
+		static string EscapeShellSingleQuoted(string value) => (value ?? string.Empty).Replace("'", "'\\''");
+
+		static void RestrictToOwner(string path)
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
 			{
-				id = value;
+				return;
 			}
-			else if (match.Groups[1].Value == ClientSecretEnvironmentVariable)
+
+			try
 			{
-				secret = value;
+				var chmod = new System.Diagnostics.ProcessStartInfo("/bin/chmod", $"600 \"{path}\"")
+				{
+					UseShellExecute = false,
+					CreateNoWindow = true
+				};
+				System.Diagnostics.Process.Start(chmod)?.WaitForExit();
 			}
-		}
-
-		return (id, secret);
-	}
-
-	public static void Write(string database, string clientId, string clientSecret)
-	{
-		var path = GetCredentialsPath(database);
-		Directory.CreateDirectory(Path.GetDirectoryName(path));
-
-		File.WriteAllText(
-			path,
-			$"# BugSplat symbol upload credentials for the '{database}' database.\n" +
-			"# Machine-local and not part of any project. Delete this file to revoke it here.\n" +
-			$"export {ClientIdEnvironmentVariable}='{EscapeShellSingleQuoted(clientId)}'\n" +
-			$"export {ClientSecretEnvironmentVariable}='{EscapeShellSingleQuoted(clientSecret)}'\n");
-
-		RestrictToOwner(path);
-	}
-
-	public static bool Clear(string database)
-	{
-		var path = GetCredentialsPath(database);
-		if (!File.Exists(path))
-		{
-			return false;
-		}
-
-		File.Delete(path);
-		return true;
-	}
-
-	// Database names are subdomains of bugsplat.com, so this should never alter a real one - it is
-	// here so a malformed value cannot escape the credentials directory.
-	static string SanitizeDatabase(string database)
-	{
-		if (string.IsNullOrWhiteSpace(database))
-		{
-			return "unknown";
-		}
-
-		return Regex.Replace(database.Trim(), @"[^A-Za-z0-9_.-]", "_");
-	}
-
-	static string EscapeShellSingleQuoted(string value) => (value ?? string.Empty).Replace("'", "'\\''");
-
-	static void RestrictToOwner(string path)
-	{
-		if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
-		{
-			return;
-		}
-
-		try
-		{
-			var chmod = new System.Diagnostics.ProcessStartInfo("/bin/chmod", $"600 \"{path}\"")
+			catch (Exception ex)
 			{
-				UseShellExecute = false,
-				CreateNoWindow = true
-			};
-			System.Diagnostics.Process.Start(chmod)?.WaitForExit();
-		}
-		catch (Exception ex)
-		{
-			UnityEngine.Debug.LogWarning($"BugSplat: could not restrict permissions on {path}: {ex.Message}");
+				UnityEngine.Debug.LogWarning($"BugSplat: could not restrict permissions on {path}: {ex.Message}");
+			}
 		}
 	}
 }

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -24,672 +24,675 @@ using UnityEditor.iOS.Xcode;
 using UnityEditor.WindowsStandalone;
 #endif
 
-public class BuildPostprocessors
+namespace BugSplatUnity.Editor
 {
-	static string _platform;
-
-	const string SymUploaderWindows = "symbol-upload-windows.exe";
-	const string SymUploaderMacOS = "symbol-upload-macos";
-	const string SymUploaderLinux = "symbol-upload-linux";
-
-	internal static string GetSymUploaderName() =>
-		Application.platform switch
-		{
-			RuntimePlatform.WindowsEditor => SymUploaderWindows,
-			RuntimePlatform.OSXEditor => SymUploaderMacOS,
-			RuntimePlatform.LinuxEditor => SymUploaderLinux,
-			_ => throw new InvalidOperationException($"BugSplat. Failed to obtain symbol uploader for {Application.platform}")
-		};
-
-	internal static string GetSymUploaderPath()
+	public class BuildPostprocessors
 	{
-		var uploaderName = GetSymUploaderName();
-		var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(BuildPostprocessors).Assembly);
-		var packageRoot = packageInfo?.resolvedPath ?? Path.GetFullPath(Path.Combine("Packages", "com.bugsplat.unity"));
-		var packagePath = Path.Combine(packageRoot, "Editor", uploaderName);
+		static string _platform;
 
-		// Registry and git installs resolve under Library/PackageCache, which Unity owns and may
-		// re-extract, so anything we have to download has to land outside the package.
-		return File.Exists(packagePath)
-			? packagePath
-			: Path.GetFullPath(Path.Combine("Temp", uploaderName));
-	}
+		const string SymUploaderWindows = "symbol-upload-windows.exe";
+		const string SymUploaderMacOS = "symbol-upload-macos";
+		const string SymUploaderLinux = "symbol-upload-linux";
 
-	/// <summary>
-	/// Upload Asset/Plugin symbol files to BugSplat. 
-	/// We don't upload Unity symbol files because the build output only contains public symbol information.
-	/// BugSplat is configured to use the Unity symbol server which has private symbols containing file, function, and line information.
-	/// </summary>
-	[PostProcessBuild(1)]
-	public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
-	{
-		var options = GetBugSplatOptions();
+		internal static string GetSymUploaderName() =>
+			Application.platform switch
+			{
+				RuntimePlatform.WindowsEditor => SymUploaderWindows,
+				RuntimePlatform.OSXEditor => SymUploaderMacOS,
+				RuntimePlatform.LinuxEditor => SymUploaderLinux,
+				_ => throw new InvalidOperationException($"BugSplat. Failed to obtain symbol uploader for {Application.platform}")
+			};
 
-		if (options == null)
+		internal static string GetSymUploaderPath()
 		{
-			Debug.LogWarning("No BugSplatOptions ScriptableObject found! Skipping build post-process tasks...");
-			return;
+			var uploaderName = GetSymUploaderName();
+			var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(BuildPostprocessors).Assembly);
+			var packageRoot = packageInfo?.resolvedPath ?? Path.GetFullPath(Path.Combine("Packages", "com.bugsplat.unity"));
+			var packagePath = Path.Combine(packageRoot, "Editor", uploaderName);
+
+			// Registry and git installs resolve under Library/PackageCache, which Unity owns and may
+			// re-extract, so anything we have to download has to land outside the package.
+			return File.Exists(packagePath)
+				? packagePath
+				: Path.GetFullPath(Path.Combine("Temp", uploaderName));
 		}
 
+		/// <summary>
+		/// Upload Asset/Plugin symbol files to BugSplat. 
+		/// We don't upload Unity symbol files because the build output only contains public symbol information.
+		/// BugSplat is configured to use the Unity symbol server which has private symbols containing file, function, and line information.
+		/// </summary>
+		[PostProcessBuild(1)]
+		public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
+		{
+			var options = GetBugSplatOptions();
+
+			if (options == null)
+			{
+				Debug.LogWarning("No BugSplatOptions ScriptableObject found! Skipping build post-process tasks...");
+				return;
+			}
+
 #if UNITY_IOS
-		if (target == BuildTarget.iOS)
-			PostProcessIos(pathToBuiltProject, options);
+			if (target == BuildTarget.iOS)
+				PostProcessIos(pathToBuiltProject, options);
 #elif UNITY_ANDROID
-		if (target == BuildTarget.Android)
-			UploadSymbolsAndroid(pathToBuiltProject, options);
+			if (target == BuildTarget.Android)
+				UploadSymbolsAndroid(pathToBuiltProject, options);
 #endif
-		if (target == BuildTarget.StandaloneWindows64 || target == BuildTarget.StandaloneWindows)
-		{
-			PostProcessWindows(pathToBuiltProject, options);
-			UploadSymbolFilesWin(pathToBuiltProject, options);
+			if (target == BuildTarget.StandaloneWindows64 || target == BuildTarget.StandaloneWindows)
+			{
+				PostProcessWindows(pathToBuiltProject, options);
+				UploadSymbolFilesWin(pathToBuiltProject, options);
+			}
+
+			if (target == BuildTarget.StandaloneOSX)
+				PostProcessMac(pathToBuiltProject, options);
 		}
 
-		if (target == BuildTarget.StandaloneOSX)
-			PostProcessMac(pathToBuiltProject, options);
-	}
-
-	// Zips a single file with the entry at the archive root and writes it to destZip.
-	// symbol-upload skips no-dbgId files (e.g. LineNumberMappings.json) but uploads
-	// .zip files as-is via the versions path, so we zip the mapping before upload.
-	private static void ZipForUpload(string sourceFile, string destZip)
-	{
-		if (File.Exists(destZip))
+		// Zips a single file with the entry at the archive root and writes it to destZip.
+		// symbol-upload skips no-dbgId files (e.g. LineNumberMappings.json) but uploads
+		// .zip files as-is via the versions path, so we zip the mapping before upload.
+		private static void ZipForUpload(string sourceFile, string destZip)
 		{
-			File.Delete(destZip);
+			if (File.Exists(destZip))
+			{
+				File.Delete(destZip);
+			}
+
+			using (var archive = ZipFile.Open(destZip, ZipArchiveMode.Create))
+			{
+				archive.CreateEntryFromFile(sourceFile, Path.GetFileName(sourceFile));
+			}
 		}
 
-		using (var archive = ZipFile.Open(destZip, ZipArchiveMode.Create))
+		private static void UploadSymbolFilesWin(string pathToBuiltProject, BugSplatOptions options)
 		{
-			archive.CreateEntryFromFile(sourceFile, Path.GetFileName(sourceFile));
-		}
-	}
-
-	private static void UploadSymbolFilesWin(string pathToBuiltProject, BugSplatOptions options)
-	{
 #if UNITY_EDITOR_WIN
-		if (!UnityEditor.WindowsStandalone.UserBuildSettings.copyPDBFiles)
-		{
-			Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Copy PDB files\" is disabled in BuildSettings->Windows.");
-			return;
-		}
+			if (!UnityEditor.WindowsStandalone.UserBuildSettings.copyPDBFiles)
+			{
+				Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Copy PDB files\" is disabled in BuildSettings->Windows.");
+				return;
+			}
 #else
-		Debug.LogWarning("BugSplat. \"Copy PDB files\" (BuildSettings->Windows) can only be read from a Windows editor, so it was not checked. If it is disabled the build contains no .pdb files and Windows crash reports will not symbolicate.");
+			Debug.LogWarning("BugSplat. \"Copy PDB files\" (BuildSettings->Windows) can only be read from a Windows editor, so it was not checked. If it is disabled the build contains no .pdb files and Windows crash reports will not symbolicate.");
 #endif
 
-		UploadSymbols(Path.GetDirectoryName(pathToBuiltProject), "**/{*.pdb,*.dll,*.exe,LineNumberMappings.json.zip}", options, uploadExitCode =>
-		{
-			if (uploadExitCode != 0)
+			UploadSymbols(Path.GetDirectoryName(pathToBuiltProject), "**/{*.pdb,*.dll,*.exe,LineNumberMappings.json.zip}", options, uploadExitCode =>
 			{
-				Debug.LogError("BugSplat. Could not upload symbols.");
+				if (uploadExitCode != 0)
+				{
+					Debug.LogError("BugSplat. Could not upload symbols.");
+					return;
+				}
+
+				Debug.Log("BugSplat. Symbols uploading completed.");
+			});
+		}
+
+		private static void PostProcessWindows(string pathToBuiltProject, BugSplatOptions options)
+		{
+			var buildDir = Path.GetDirectoryName(pathToBuiltProject);
+			if (buildDir == null)
+			{
+				Debug.LogError("BugSplat. Could not find build directory. Skipping Windows post-build tasks.");
 				return;
 			}
 
-			Debug.Log("BugSplat. Symbols uploading completed.");
-		});
-	}
+			CopyWindowsLineNumberMappings(buildDir);
 
-	private static void PostProcessWindows(string pathToBuiltProject, BugSplatOptions options)
-	{
-		var buildDir = Path.GetDirectoryName(pathToBuiltProject);
-		if (buildDir == null)
-		{
-			Debug.LogError("BugSplat. Could not find build directory. Skipping Windows post-build tasks.");
-			return;
-		}
-
-		CopyWindowsLineNumberMappings(buildDir);
-
-		if (!options.UseNativeCrashReportingForWindows)
-			return;
-
-		string arch;
-		try
-		{
-			arch = GetPEMachineArchitecture(pathToBuiltProject);
-		}
-		catch (Exception ex)
-		{
-			Debug.LogError($"BugSplat. Could not determine built executable architecture: {ex.Message}. Skipping native runtime support file copy.");
-			return;
-		}
-
-		var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(BuildPostprocessors).Assembly);
-		var packageRoot = packageInfo?.resolvedPath ?? Path.GetFullPath(Path.Combine("Packages", "com.bugsplat.unity"));
-		var supportDir = Path.Combine(packageRoot, "Runtime", "Plugins", "Windows", "Support~", arch);
-
-		foreach (var fileName in new[] { "BugSplatMonitor.exe", "BugSplatRc.dll", "BugSplatWer.dll" })
-		{
-			var source = Path.Combine(supportDir, fileName);
-			if (!File.Exists(source))
-			{
-				Debug.LogError($"BugSplat. Missing native runtime support file {source}. Native crash reports may not upload.");
-				continue;
-			}
-
-			File.Copy(source, Path.Combine(buildDir, fileName), true);
-		}
-
-		Debug.Log($"BugSplat. Copied Windows native runtime support files ({arch}) next to the built executable.");
-	}
-
-	private static void CopyWindowsLineNumberMappings(string buildDir)
-	{
-		// Copy LineNumberMappings.json for IL2CPP symbolication. Mono builds don't produce one.
-		var mappingSearchPaths = new[]
-		{
-			Path.Combine("Library", "Bee", "artifacts", "WinPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "WinPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "WindowsPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "WindowsPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
-		};
-
-		foreach (var searchPath in mappingSearchPaths)
-		{
-			var fullPath = Path.GetFullPath(searchPath);
-			if (File.Exists(fullPath))
-			{
-				var destZip = Path.Combine(buildDir, "LineNumberMappings.json.zip");
-				ZipForUpload(fullPath, destZip);
-				Debug.Log($"BugSplat: Zipped LineNumberMappings.json for upload ({new FileInfo(fullPath).Length / 1024}KB -> {new FileInfo(destZip).Length / 1024}KB); symbol-upload skips the raw .json (no dbgId), the .zip uploads via the versions path.");
+			if (!options.UseNativeCrashReportingForWindows)
 				return;
-			}
-		}
 
-		Debug.Log("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available for Windows. This is expected for Mono builds.");
-	}
-
-	private static string GetPEMachineArchitecture(string exePath)
-	{
-		// Read the COFF machine field from the PE header: 0x014C = x86, 0x8664 = x64, 0xAA64 = ARM64
-		using (var stream = File.OpenRead(exePath))
-		using (var reader = new BinaryReader(stream))
-		{
-			stream.Seek(0x3C, SeekOrigin.Begin);
-			var peHeaderOffset = reader.ReadInt32();
-			stream.Seek(peHeaderOffset + 4, SeekOrigin.Begin);
-			var machine = reader.ReadUInt16();
-
-			switch (machine)
+			string arch;
+			try
 			{
-				case 0x014C:
-					return "x86";
-				case 0x8664:
-					return "x64";
-				case 0xAA64:
-					return "ARM64";
-				default:
-					throw new InvalidOperationException($"Unsupported PE machine type 0x{machine:X4}");
+				arch = GetPEMachineArchitecture(pathToBuiltProject);
 			}
-		}
-	}
-
-	private static void PostProcessMac(string pathToBuiltProject, BugSplatOptions options)
-	{
-		if (!options.UploadDebugSymbolsForMac)
-			return;
-
-		// Skip symbol upload for Xcode project exports — dSYMs don't exist yet
-		if (Directory.GetFiles(pathToBuiltProject, "*.xcodeproj", SearchOption.TopDirectoryOnly).Length > 0
-			|| Directory.GetDirectories(pathToBuiltProject, "*.xcodeproj", SearchOption.TopDirectoryOnly).Length > 0)
-		{
-			Debug.Log("BugSplat: Xcode project export detected, skipping symbol upload. Symbols will be available after building in Xcode.");
-			return;
-		}
-
-		var buildDir = Path.GetDirectoryName(pathToBuiltProject);
-		if (buildDir == null)
-		{
-			Debug.LogError("BugSplat. Could not find build directory. Will not upload macOS debug symbols.");
-			return;
-		}
-
-		// Copy LineNumberMappings.json for IL2CPP symbolication
-		var mappingSearchPaths = new[]
-		{
-			Path.Combine("Library", "Bee", "artifacts", "MacStandalonePlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "MacStandalonePlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "MacPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "MacPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
-		};
-
-		var mappingFound = false;
-		foreach (var searchPath in mappingSearchPaths)
-		{
-			var fullPath = Path.GetFullPath(searchPath);
-			if (File.Exists(fullPath))
+			catch (Exception ex)
 			{
-				var destZip = Path.Combine(buildDir, "LineNumberMappings.json.zip");
-				ZipForUpload(fullPath, destZip);
-				Debug.Log($"BugSplat: Zipped LineNumberMappings.json for upload ({new FileInfo(fullPath).Length / 1024}KB -> {new FileInfo(destZip).Length / 1024}KB); symbol-upload skips the raw .json (no dbgId), the .zip uploads via the versions path.");
-				mappingFound = true;
-				break;
-			}
-		}
-
-		if (!mappingFound)
-		{
-			Debug.LogWarning("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available for macOS. Ensure Scripting Backend is set to IL2CPP.");
-		}
-
-		UploadSymbols(buildDir, "**/{*.dSYM,LineNumberMappings.json.zip}", options, uploadExitCode =>
-		{
-			if (uploadExitCode != 0)
-			{
-				Debug.LogError("BugSplat. Could not upload macOS symbols.");
+				Debug.LogError($"BugSplat. Could not determine built executable architecture: {ex.Message}. Skipping native runtime support file copy.");
 				return;
 			}
 
-			Debug.Log("BugSplat. macOS symbols uploading completed.");
-		});
-	}
+			var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(BuildPostprocessors).Assembly);
+			var packageRoot = packageInfo?.resolvedPath ?? Path.GetFullPath(Path.Combine("Packages", "com.bugsplat.unity"));
+			var supportDir = Path.Combine(packageRoot, "Runtime", "Plugins", "Windows", "Support~", arch);
 
-	internal static BugSplatOptions GetBugSplatOptions()
-	{
-		var guids = AssetDatabase.FindAssets("t:BugSplatOptions");
+			foreach (var fileName in new[] { "BugSplatMonitor.exe", "BugSplatRc.dll", "BugSplatWer.dll" })
+			{
+				var source = Path.Combine(supportDir, fileName);
+				if (!File.Exists(source))
+				{
+					Debug.LogError($"BugSplat. Missing native runtime support file {source}. Native crash reports may not upload.");
+					continue;
+				}
 
-		if (guids.Length == 0)
-		{
-			return null;
+				File.Copy(source, Path.Combine(buildDir, fileName), true);
+			}
+
+			Debug.Log($"BugSplat. Copied Windows native runtime support files ({arch}) next to the built executable.");
 		}
 
-		var path = AssetDatabase.GUIDToAssetPath(guids[0]);
-		return AssetDatabase.LoadAssetAtPath<BugSplatOptions>(path);
-	}
+		private static void CopyWindowsLineNumberMappings(string buildDir)
+		{
+			// Copy LineNumberMappings.json for IL2CPP symbolication. Mono builds don't produce one.
+			var mappingSearchPaths = new[]
+			{
+				Path.Combine("Library", "Bee", "artifacts", "WinPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "WinPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "WindowsPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "WindowsPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
+			};
+
+			foreach (var searchPath in mappingSearchPaths)
+			{
+				var fullPath = Path.GetFullPath(searchPath);
+				if (File.Exists(fullPath))
+				{
+					var destZip = Path.Combine(buildDir, "LineNumberMappings.json.zip");
+					ZipForUpload(fullPath, destZip);
+					Debug.Log($"BugSplat: Zipped LineNumberMappings.json for upload ({new FileInfo(fullPath).Length / 1024}KB -> {new FileInfo(destZip).Length / 1024}KB); symbol-upload skips the raw .json (no dbgId), the .zip uploads via the versions path.");
+					return;
+				}
+			}
+
+			Debug.Log("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available for Windows. This is expected for Mono builds.");
+		}
+
+		private static string GetPEMachineArchitecture(string exePath)
+		{
+			// Read the COFF machine field from the PE header: 0x014C = x86, 0x8664 = x64, 0xAA64 = ARM64
+			using (var stream = File.OpenRead(exePath))
+			using (var reader = new BinaryReader(stream))
+			{
+				stream.Seek(0x3C, SeekOrigin.Begin);
+				var peHeaderOffset = reader.ReadInt32();
+				stream.Seek(peHeaderOffset + 4, SeekOrigin.Begin);
+				var machine = reader.ReadUInt16();
+
+				switch (machine)
+				{
+					case 0x014C:
+						return "x86";
+					case 0x8664:
+						return "x64";
+					case 0xAA64:
+						return "ARM64";
+					default:
+						throw new InvalidOperationException($"Unsupported PE machine type 0x{machine:X4}");
+				}
+			}
+		}
+
+		private static void PostProcessMac(string pathToBuiltProject, BugSplatOptions options)
+		{
+			if (!options.UploadDebugSymbolsForMac)
+				return;
+
+			// Skip symbol upload for Xcode project exports — dSYMs don't exist yet
+			if (Directory.GetFiles(pathToBuiltProject, "*.xcodeproj", SearchOption.TopDirectoryOnly).Length > 0
+				|| Directory.GetDirectories(pathToBuiltProject, "*.xcodeproj", SearchOption.TopDirectoryOnly).Length > 0)
+			{
+				Debug.Log("BugSplat: Xcode project export detected, skipping symbol upload. Symbols will be available after building in Xcode.");
+				return;
+			}
+
+			var buildDir = Path.GetDirectoryName(pathToBuiltProject);
+			if (buildDir == null)
+			{
+				Debug.LogError("BugSplat. Could not find build directory. Will not upload macOS debug symbols.");
+				return;
+			}
+
+			// Copy LineNumberMappings.json for IL2CPP symbolication
+			var mappingSearchPaths = new[]
+			{
+				Path.Combine("Library", "Bee", "artifacts", "MacStandalonePlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "MacStandalonePlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "MacPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "MacPlayerBuildProgram", "il2cppOutput", "LineNumberMappings.json"),
+			};
+
+			var mappingFound = false;
+			foreach (var searchPath in mappingSearchPaths)
+			{
+				var fullPath = Path.GetFullPath(searchPath);
+				if (File.Exists(fullPath))
+				{
+					var destZip = Path.Combine(buildDir, "LineNumberMappings.json.zip");
+					ZipForUpload(fullPath, destZip);
+					Debug.Log($"BugSplat: Zipped LineNumberMappings.json for upload ({new FileInfo(fullPath).Length / 1024}KB -> {new FileInfo(destZip).Length / 1024}KB); symbol-upload skips the raw .json (no dbgId), the .zip uploads via the versions path.");
+					mappingFound = true;
+					break;
+				}
+			}
+
+			if (!mappingFound)
+			{
+				Debug.LogWarning("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available for macOS. Ensure Scripting Backend is set to IL2CPP.");
+			}
+
+			UploadSymbols(buildDir, "**/{*.dSYM,LineNumberMappings.json.zip}", options, uploadExitCode =>
+			{
+				if (uploadExitCode != 0)
+				{
+					Debug.LogError("BugSplat. Could not upload macOS symbols.");
+					return;
+				}
+
+				Debug.Log("BugSplat. macOS symbols uploading completed.");
+			});
+		}
+
+		internal static BugSplatOptions GetBugSplatOptions()
+		{
+			var guids = AssetDatabase.FindAssets("t:BugSplatOptions");
+
+			if (guids.Length == 0)
+			{
+				return null;
+			}
+
+			var path = AssetDatabase.GUIDToAssetPath(guids[0]);
+			return AssetDatabase.LoadAssetAtPath<BugSplatOptions>(path);
+		}
 
 #if UNITY_IOS
-	private static void PostProcessIos(string pathToBuiltProject, BugSplatOptions options)
-	{
-		var projectPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
-
-		var project = new PBXProject();
-		project.ReadFromString(File.ReadAllText(projectPath));
-
-		var targetGuid = project.GetUnityFrameworkTargetGuid();
-
-		project.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-ObjC");
-		project.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-lz");
-		project.AddBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
-
-		project.SetBuildProperty(targetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
-
-		var mainTargetGuid = project.GetUnityMainTargetGuid();
-		project.AddBuildProperty(mainTargetGuid, "ENABLE_BITCODE", "NO");
-		project.SetBuildProperty(mainTargetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
-
-		HandleUploadSymbols(mainTargetGuid, project, options);
-
-		File.WriteAllText(projectPath, project.WriteToString());
-
-		CopyLineNumberMappings(pathToBuiltProject);
-
-		if (options.UseNativeCrashReportingForIos)
-			DisableUnityCrashReporter(pathToBuiltProject);
-	}
-
-	private static void CopyLineNumberMappings(string pathToBuiltProject)
-	{
-		var searchPaths = new[]
+		private static void PostProcessIos(string pathToBuiltProject, BugSplatOptions options)
 		{
-			Path.Combine("Library", "Bee", "artifacts", "iOS", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-			Path.Combine("Library", "Bee", "artifacts", "iOSPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
-		};
+			var projectPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
 
-		foreach (var searchPath in searchPaths)
+			var project = new PBXProject();
+			project.ReadFromString(File.ReadAllText(projectPath));
+
+			var targetGuid = project.GetUnityFrameworkTargetGuid();
+
+			project.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-ObjC");
+			project.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-lz");
+			project.AddBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+
+			project.SetBuildProperty(targetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
+
+			var mainTargetGuid = project.GetUnityMainTargetGuid();
+			project.AddBuildProperty(mainTargetGuid, "ENABLE_BITCODE", "NO");
+			project.SetBuildProperty(mainTargetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
+
+			HandleUploadSymbols(mainTargetGuid, project, options);
+
+			File.WriteAllText(projectPath, project.WriteToString());
+
+			CopyLineNumberMappings(pathToBuiltProject);
+
+			if (options.UseNativeCrashReportingForIos)
+				DisableUnityCrashReporter(pathToBuiltProject);
+		}
+
+		private static void CopyLineNumberMappings(string pathToBuiltProject)
 		{
-			var fullPath = Path.GetFullPath(searchPath);
-			if (File.Exists(fullPath))
+			var searchPaths = new[]
 			{
-				var dest = Path.Combine(pathToBuiltProject, "LineNumberMappings.json");
-				File.Copy(fullPath, dest, true);
-				Debug.Log($"BugSplat: Copied LineNumberMappings.json to Xcode project ({new FileInfo(fullPath).Length / 1024}KB)");
+				Path.Combine("Library", "Bee", "artifacts", "iOS", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+				Path.Combine("Library", "Bee", "artifacts", "iOSPlayerBuildProgram", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json"),
+			};
+
+			foreach (var searchPath in searchPaths)
+			{
+				var fullPath = Path.GetFullPath(searchPath);
+				if (File.Exists(fullPath))
+				{
+					var dest = Path.Combine(pathToBuiltProject, "LineNumberMappings.json");
+					File.Copy(fullPath, dest, true);
+					Debug.Log($"BugSplat: Copied LineNumberMappings.json to Xcode project ({new FileInfo(fullPath).Length / 1024}KB)");
+					return;
+				}
+			}
+
+			Debug.LogWarning("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available. Ensure Scripting Backend is set to IL2CPP.");
+		}
+
+		private static void DisableUnityCrashReporter(string pathToBuiltProject)
+		{
+			var crashReporterPath = Path.Combine(pathToBuiltProject, "Classes", "CrashReporter.h");
+			if (!File.Exists(crashReporterPath))
+			{
+				Debug.Log("BugSplat: CrashReporter.h not found, Unity crash reporter may not be present in this version.");
 				return;
+			}
+
+			var content = File.ReadAllText(crashReporterPath);
+			var modified = content
+				.Replace("#define ENABLE_CUSTOM_CRASH_REPORTER 1", "#define ENABLE_CUSTOM_CRASH_REPORTER 0")
+				.Replace("#define ENABLE_CRASH_REPORT_SUBMISSION 1", "#define ENABLE_CRASH_REPORT_SUBMISSION 0");
+
+			if (content != modified)
+			{
+				File.WriteAllText(crashReporterPath, modified);
+				Debug.Log("BugSplat: Disabled Unity's built-in crash reporter to prevent PLCrashReporter conflict.");
 			}
 		}
 
-		Debug.LogWarning("BugSplat: LineNumberMappings.json not found. IL2CPP C# symbolication will not be available. Ensure Scripting Backend is set to IL2CPP.");
-	}
-
-	private static void DisableUnityCrashReporter(string pathToBuiltProject)
-	{
-		var crashReporterPath = Path.Combine(pathToBuiltProject, "Classes", "CrashReporter.h");
-		if (!File.Exists(crashReporterPath))
+		private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options)
 		{
-			Debug.Log("BugSplat: CrashReporter.h not found, Unity crash reporter may not be present in this version.");
-			return;
+			if (!options.UploadDebugSymbolsForIos)
+				return;
+
+			if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out _, out _))
+			{
+				Debug.LogWarning(
+					$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
+					$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
+					$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable} in the Xcode build environment, or use " +
+					"BugSplat > Symbol Upload > Set Credentials. The dSYM upload build phase will skip uploading without them.");
+			}
+
+			var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
+			var version = string.IsNullOrEmpty(options.Version) ? Application.version : options.Version;
+
+			// Resolved against $HOME at Xcode build time, so the credentials never enter the project
+			// and the generated script carries no path from the machine that ran the Unity build.
+			var credentialsRelativePath = BugSplatSymbolUploadCredentials.GetCredentialsPathRelativeToHome(options.Database);
+
+			const string shellPath = "/bin/sh";
+			const int index = 999;
+			const string name = "Upload dSYM files to BugSplat";
+			var shellScript =
+				$"BUGSPLAT_CREDENTIALS=\"$HOME/{credentialsRelativePath}\"\n" +
+				$"if [ -f \"$BUGSPLAT_CREDENTIALS\" ]; then\n" +
+				$"    . \"$BUGSPLAT_CREDENTIALS\"\n" +
+				$"fi\n" +
+				$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] || [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ]; then\n" +
+				$"    echo \"warning: BugSplat symbol upload credentials not found. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or run BugSplat > Symbol Upload > Set Credentials in Unity. Skipping dSYM upload.\"\n" +
+				$"    exit 0\n" +
+				$"fi\n" +
+				$"export SYMBOL_UPLOAD_CLIENT_ID SYMBOL_UPLOAD_CLIENT_SECRET\n\n" +
+				$"if [ \"$(uname -m)\" = \"x86_64\" ]; then\n" +
+				$"    VARIANT=\"symbol-upload-macos-intel\"\n" +
+				$"else\n" +
+				$"    VARIANT=\"symbol-upload-macos\"\n" +
+				$"fi\n" +
+				$"SYMBOL_UPLOAD=\"${{TMPDIR}}/$VARIANT\"\n" +
+				$"if [ ! -f \"$SYMBOL_UPLOAD\" ]; then\n" +
+				$"    echo \"Downloading $VARIANT...\"\n" +
+				$"    curl -sL -o \"$SYMBOL_UPLOAD\" \"https://app.bugsplat.com/download/$VARIANT\"\n" +
+				$"    chmod +x \"$SYMBOL_UPLOAD\"\n" +
+				$"fi\n\n" +
+				$"\"$SYMBOL_UPLOAD\" \\\n" +
+				$"    --database \"{options.Database}\" \\\n" +
+				$"    --application \"{application}\" \\\n" +
+				$"    --version \"{version}\" \\\n" +
+				$"    --files \"**/*.dSYM\" \\\n" +
+				$"    --directory \"${{BUILT_PRODUCTS_DIR}}\"\n\n" +
+				$"# Upload LineNumberMappings.json for IL2CPP C# symbolication.\n" +
+				$"# symbol-upload skips the raw .json (no dbgId), so zip it; the .zip uploads via the versions path.\n" +
+				$"MAPPINGS=\"${{PROJECT_DIR}}/LineNumberMappings.json\"\n" +
+				$"if [ -f \"$MAPPINGS\" ]; then\n" +
+				$"    (cd \"${{PROJECT_DIR}}\" && zip -j -q LineNumberMappings.json.zip LineNumberMappings.json)\n" +
+				$"    \"$SYMBOL_UPLOAD\" \\\n" +
+				$"        --database \"{options.Database}\" \\\n" +
+				$"        --application \"{application}\" \\\n" +
+				$"        --version \"{version}\" \\\n" +
+				$"        --files \"LineNumberMappings.json.zip\" \\\n" +
+				$"        --directory \"${{PROJECT_DIR}}\"\n" +
+				$"fi";
+
+			if (!string.IsNullOrEmpty(project.GetShellScriptBuildPhaseForTarget(targetGuid, name, shellPath, shellScript)))
+				return;
+
+			// GetShellScriptBuildPhaseForTarget matches on name, shellPath *and* script body, so a phase
+			// written by an older version does not match this one. Inserting regardless would leave two
+			// phases, with the older one still uploading - and, before this change, still carrying
+			// credentials inlined into project.pbxproj.
+			if (HasBuildPhaseNamed(project, targetGuid, name))
+			{
+				Debug.LogWarning(
+					$"BugSplat: the Xcode project already has a '{name}' build phase from an earlier version, so a new one was not added. " +
+					"Delete that phase and build again, or export with Replace instead of Append. " +
+					"If it was generated before 5.0.0 it contains your symbol upload Client ID and Secret in plain text - rotate them.");
+				return;
+			}
+
+			project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
 		}
 
-		var content = File.ReadAllText(crashReporterPath);
-		var modified = content
-			.Replace("#define ENABLE_CUSTOM_CRASH_REPORTER 1", "#define ENABLE_CUSTOM_CRASH_REPORTER 0")
-			.Replace("#define ENABLE_CRASH_REPORT_SUBMISSION 1", "#define ENABLE_CRASH_REPORT_SUBMISSION 0");
-
-		if (content != modified)
+		private static bool HasBuildPhaseNamed(PBXProject project, string targetGuid, string name)
 		{
-			File.WriteAllText(crashReporterPath, modified);
-			Debug.Log("BugSplat: Disabled Unity's built-in crash reporter to prevent PLCrashReporter conflict.");
+			foreach (var phaseGuid in project.GetAllBuildPhasesForTarget(targetGuid))
+			{
+				if (string.Equals(project.GetBuildPhaseName(phaseGuid), name))
+					return true;
+			}
+
+			return false;
 		}
-	}
-
-	private static void HandleUploadSymbols(string targetGuid, PBXProject project, BugSplatOptions options)
-	{
-		if (!options.UploadDebugSymbolsForIos)
-			return;
-
-		if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out _, out _))
-		{
-			Debug.LogWarning(
-				$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
-				$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
-				$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable} in the Xcode build environment, or use " +
-				"BugSplat > Symbol Upload > Set Credentials. The dSYM upload build phase will skip uploading without them.");
-		}
-
-		var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
-		var version = string.IsNullOrEmpty(options.Version) ? Application.version : options.Version;
-
-		// Resolved against $HOME at Xcode build time, so the credentials never enter the project
-		// and the generated script carries no path from the machine that ran the Unity build.
-		var credentialsRelativePath = BugSplatSymbolUploadCredentials.GetCredentialsPathRelativeToHome(options.Database);
-
-		const string shellPath = "/bin/sh";
-		const int index = 999;
-		const string name = "Upload dSYM files to BugSplat";
-		var shellScript =
-			$"BUGSPLAT_CREDENTIALS=\"$HOME/{credentialsRelativePath}\"\n" +
-			$"if [ -f \"$BUGSPLAT_CREDENTIALS\" ]; then\n" +
-			$"    . \"$BUGSPLAT_CREDENTIALS\"\n" +
-			$"fi\n" +
-			$"if [ -z \"$SYMBOL_UPLOAD_CLIENT_ID\" ] || [ -z \"$SYMBOL_UPLOAD_CLIENT_SECRET\" ]; then\n" +
-			$"    echo \"warning: BugSplat symbol upload credentials not found. Set SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or run BugSplat > Symbol Upload > Set Credentials in Unity. Skipping dSYM upload.\"\n" +
-			$"    exit 0\n" +
-			$"fi\n" +
-			$"export SYMBOL_UPLOAD_CLIENT_ID SYMBOL_UPLOAD_CLIENT_SECRET\n\n" +
-			$"if [ \"$(uname -m)\" = \"x86_64\" ]; then\n" +
-			$"    VARIANT=\"symbol-upload-macos-intel\"\n" +
-			$"else\n" +
-			$"    VARIANT=\"symbol-upload-macos\"\n" +
-			$"fi\n" +
-			$"SYMBOL_UPLOAD=\"${{TMPDIR}}/$VARIANT\"\n" +
-			$"if [ ! -f \"$SYMBOL_UPLOAD\" ]; then\n" +
-			$"    echo \"Downloading $VARIANT...\"\n" +
-			$"    curl -sL -o \"$SYMBOL_UPLOAD\" \"https://app.bugsplat.com/download/$VARIANT\"\n" +
-			$"    chmod +x \"$SYMBOL_UPLOAD\"\n" +
-			$"fi\n\n" +
-			$"\"$SYMBOL_UPLOAD\" \\\n" +
-			$"    --database \"{options.Database}\" \\\n" +
-			$"    --application \"{application}\" \\\n" +
-			$"    --version \"{version}\" \\\n" +
-			$"    --files \"**/*.dSYM\" \\\n" +
-			$"    --directory \"${{BUILT_PRODUCTS_DIR}}\"\n\n" +
-			$"# Upload LineNumberMappings.json for IL2CPP C# symbolication.\n" +
-			$"# symbol-upload skips the raw .json (no dbgId), so zip it; the .zip uploads via the versions path.\n" +
-			$"MAPPINGS=\"${{PROJECT_DIR}}/LineNumberMappings.json\"\n" +
-			$"if [ -f \"$MAPPINGS\" ]; then\n" +
-			$"    (cd \"${{PROJECT_DIR}}\" && zip -j -q LineNumberMappings.json.zip LineNumberMappings.json)\n" +
-			$"    \"$SYMBOL_UPLOAD\" \\\n" +
-			$"        --database \"{options.Database}\" \\\n" +
-			$"        --application \"{application}\" \\\n" +
-			$"        --version \"{version}\" \\\n" +
-			$"        --files \"LineNumberMappings.json.zip\" \\\n" +
-			$"        --directory \"${{PROJECT_DIR}}\"\n" +
-			$"fi";
-
-		if (!string.IsNullOrEmpty(project.GetShellScriptBuildPhaseForTarget(targetGuid, name, shellPath, shellScript)))
-			return;
-
-		// GetShellScriptBuildPhaseForTarget matches on name, shellPath *and* script body, so a phase
-		// written by an older version does not match this one. Inserting regardless would leave two
-		// phases, with the older one still uploading - and, before this change, still carrying
-		// credentials inlined into project.pbxproj.
-		if (HasBuildPhaseNamed(project, targetGuid, name))
-		{
-			Debug.LogWarning(
-				$"BugSplat: the Xcode project already has a '{name}' build phase from an earlier version, so a new one was not added. " +
-				"Delete that phase and build again, or export with Replace instead of Append. " +
-				"If it was generated before 5.0.0 it contains your symbol upload Client ID and Secret in plain text - rotate them.");
-			return;
-		}
-
-		project.InsertShellScriptBuildPhase(index, targetGuid, name, shellPath, shellScript);
-	}
-
-	private static bool HasBuildPhaseNamed(PBXProject project, string targetGuid, string name)
-	{
-		foreach (var phaseGuid in project.GetAllBuildPhasesForTarget(targetGuid))
-		{
-			if (string.Equals(project.GetBuildPhaseName(phaseGuid), name))
-				return true;
-		}
-
-		return false;
-	}
 
 #endif
 
 #if UNITY_ANDROID
-	private static void UploadSymbolsAndroid(string pathToBuiltProject, BugSplatOptions options)
-	{
-		if (!options.UploadDebugSymbolsForAndroid)
+		private static void UploadSymbolsAndroid(string pathToBuiltProject, BugSplatOptions options)
 		{
-			return;
-		}
-
-		if (EditorUserBuildSettings.exportAsGoogleAndroidProject)
-		{
-			Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Export Project\" is enabled in BuildSettings->Android.");
-			return;
-		}
-
-		if (UnityEditor.Android.UserBuildSettings.DebugSymbols.level == Unity.Android.Types.DebugSymbolLevel.None)
-		{
-			Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Debug Symbols\" is set to None in BuildSettings->Android.");
-			return;
-		}
-
-		Debug.Log("BugSplat. Starting symbol upload.");
-
-		var buildDir = Path.GetDirectoryName(pathToBuiltProject);
-		if (buildDir == null)
-		{
-			Debug.LogError("BugSplat. Could not find build directory. Will not upload Android debug symbols.");
-			return;
-		}
-
-		var pattern = "*.symbols.zip";
-
-		var hasFoundFile = false;
-		foreach (var file in Directory.GetFiles(buildDir, pattern))
-		{
-			hasFoundFile = true;
-			ProcessSymbolsArchive(file, options);
-		}
-
-		if (!hasFoundFile)
-		{
-			Debug.LogError("BugSplat. Could not find generated symbols archive.");
-		}
-	}
-
-	private static void ProcessSymbolsArchive(string filePath, BugSplatOptions options)
-	{
-		string symbolsUnzipPath = Path.Combine(Path.GetDirectoryName(filePath), "symbols");
-
-		try
-		{
-			System.IO.Compression.ZipFile.ExtractToDirectory(filePath, symbolsUnzipPath, true);
-		}
-		catch (Exception e)
-		{
-			Debug.LogError(e);
-			return;
-		}
-
-		if(!Directory.Exists(symbolsUnzipPath))
-		{
-			Debug.LogError("BugSplat. Could not unzip generated symbols archive.");
-			return;
-		}
-
-		UploadSymbols(symbolsUnzipPath, "**/*.so", options, uploadExitCode =>
-		{
-			try
+			if (!options.UploadDebugSymbolsForAndroid)
 			{
-				Directory.Delete(symbolsUnzipPath, true);
-			}
-			catch (Exception e)
-			{
-				Debug.LogWarning($"BugSplat. Could not clean up unzipped symbols at {symbolsUnzipPath}: {e.Message}");
-			}
-
-			if (uploadExitCode != 0)
-			{
-				Debug.LogError("BugSplat. Could not upload symbols.");
 				return;
 			}
 
-			Debug.Log("BugSplat. Symbols uploading completed.");
-		});
-	}
-#endif
-
-	private static void UploadSymbols(string artifactsDirPath, string globPattern, BugSplatOptions options, Action<int> onCompleted)
-	{
-		if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out var clientId, out var clientSecret))
-		{
-			Debug.LogWarning(
-				$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
-				$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
-				$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use " +
-				"BugSplat > Symbol Upload > Set Credentials. Skipping symbol uploads.");
-			onCompleted(0);
-			return;
-		}
-
-		var symbolUploadPath = GetSymUploaderPath();
-		if (!File.Exists(symbolUploadPath) && !DownloadSymbolUpload(symbolUploadPath))
-		{
-			onCompleted(-1);
-			return;
-		}
-
-		var version = string.IsNullOrEmpty(options.Version) ? Application.version : options.Version;
-		var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
-
-		var symUploadProcessInfo = new ProcessStartInfo
-		{
-			FileName = symbolUploadPath,
-			UseShellExecute = false,
-			RedirectStandardOutput = true,
-			Arguments = $"--database {options.Database} --application \"{application}\" " +
-				$"--version \"{version}\" --files \"{globPattern}\" --directory \"{artifactsDirPath}\""
-		};
-
-		symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_ID"] = clientId;
-		symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_SECRET"] = clientSecret;
-
-		if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android)
-		{
-			symUploadProcessInfo.Arguments += " --dumpSyms";
-		}
-
-		Process uploadSymProcess;
-		try
-		{
-			uploadSymProcess = Process.Start(symUploadProcessInfo);
-		}
-		catch (Exception ex)
-		{
-			Debug.LogError($"BugSplat. Failed to start {symbolUploadPath}. Error: {ex}");
-			onCompleted(-1);
-			return;
-		}
-
-		if (uploadSymProcess == null)
-		{
-			onCompleted(-1);
-			return;
-		}
-
-		Debug.Log(uploadSymProcess.StandardOutput.ReadToEnd());
-
-		uploadSymProcess.WaitForExit();
-
-		onCompleted(uploadSymProcess.ExitCode);
-	}
-
-	private static bool DownloadSymbolUpload(string destinationPath)
-	{
-		var variant = Path.GetFileName(destinationPath);
-		var fileUrl = $"https://app.bugsplat.com/download/{variant}";
-
-		try
-		{
-			Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
-
-			using (var client = new WebClient())
+			if (EditorUserBuildSettings.exportAsGoogleAndroidProject)
 			{
-				Debug.Log($"BugSplat. Downloading {variant} to {destinationPath}");
+				Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Export Project\" is enabled in BuildSettings->Android.");
+				return;
+			}
 
-				client.DownloadFile(fileUrl, destinationPath);
+			if (UnityEditor.Android.UserBuildSettings.DebugSymbols.level == Unity.Android.Types.DebugSymbolLevel.None)
+			{
+				Debug.LogWarning("BugSplat. Skipping symbols uploading since \"Debug Symbols\" is set to None in BuildSettings->Android.");
+				return;
+			}
 
-				if (File.Exists(destinationPath))
-				{
-					Debug.Log($"BugSplat. {variant} downloaded successfully to {destinationPath}");
-				}
-				else
-				{
-					Debug.LogError($"BugSplat. Could not download {variant}");
-					return false;
-				}
+			Debug.Log("BugSplat. Starting symbol upload.");
+
+			var buildDir = Path.GetDirectoryName(pathToBuiltProject);
+			if (buildDir == null)
+			{
+				Debug.LogError("BugSplat. Could not find build directory. Will not upload Android debug symbols.");
+				return;
+			}
+
+			var pattern = "*.symbols.zip";
+
+			var hasFoundFile = false;
+			foreach (var file in Directory.GetFiles(buildDir, pattern))
+			{
+				hasFoundFile = true;
+				ProcessSymbolsArchive(file, options);
+			}
+
+			if (!hasFoundFile)
+			{
+				Debug.LogError("BugSplat. Could not find generated symbols archive.");
 			}
 		}
-		catch (WebException ex)
+
+		private static void ProcessSymbolsArchive(string filePath, BugSplatOptions options)
 		{
-			Debug.LogError($"BugSplat. Failed to download file from {fileUrl}. Error: {ex.Message}");
-			return false;
-		}
-		catch (Exception ex)
-		{
-			Debug.LogError($"BugSplat. Unexpected error during file download. Error: {ex}");
-			return false;
-		}
+			string symbolsUnzipPath = Path.Combine(Path.GetDirectoryName(filePath), "symbols");
 
-		if (Application.platform == RuntimePlatform.WindowsEditor)
-		{
-			return true;
-		}
-
-		try
-		{
-			var absolutePath = Path.GetFullPath(destinationPath);
-
-			// Run chmod +x to make the file executable
-			var process = new Process();
-			process.StartInfo.FileName = "chmod";
-			process.StartInfo.Arguments = $"+x \"{absolutePath}\"";
-			process.StartInfo.UseShellExecute = false;
-			process.StartInfo.RedirectStandardOutput = true;
-			process.StartInfo.RedirectStandardError = true;
-			process.Start();
-
-			var output = process.StandardOutput.ReadToEnd();
-			var error = process.StandardError.ReadToEnd();
-			process.WaitForExit();
-
-			if (process.ExitCode != 0)
+			try
 			{
-				Debug.LogError($"BugSplat. Failed to make {destinationPath} executable. Error: {error}");
+				System.IO.Compression.ZipFile.ExtractToDirectory(filePath, symbolsUnzipPath, true);
+			}
+			catch (Exception e)
+			{
+				Debug.LogError(e);
+				return;
+			}
+
+			if(!Directory.Exists(symbolsUnzipPath))
+			{
+				Debug.LogError("BugSplat. Could not unzip generated symbols archive.");
+				return;
+			}
+
+			UploadSymbols(symbolsUnzipPath, "**/*.so", options, uploadExitCode =>
+			{
+				try
+				{
+					Directory.Delete(symbolsUnzipPath, true);
+				}
+				catch (Exception e)
+				{
+					Debug.LogWarning($"BugSplat. Could not clean up unzipped symbols at {symbolsUnzipPath}: {e.Message}");
+				}
+
+				if (uploadExitCode != 0)
+				{
+					Debug.LogError("BugSplat. Could not upload symbols.");
+					return;
+				}
+
+				Debug.Log("BugSplat. Symbols uploading completed.");
+			});
+		}
+#endif
+
+		private static void UploadSymbols(string artifactsDirPath, string globPattern, BugSplatOptions options, Action<int> onCompleted)
+		{
+			if (!BugSplatSymbolUploadCredentials.TryResolve(options.Database, out var clientId, out var clientSecret))
+			{
+				Debug.LogWarning(
+					$"BugSplat: no symbol upload credentials for database '{options.Database}'. Set " +
+					$"{BugSplatSymbolUploadCredentials.ClientIdEnvironmentVariable} and " +
+					$"{BugSplatSymbolUploadCredentials.ClientSecretEnvironmentVariable}, or use " +
+					"BugSplat > Symbol Upload > Set Credentials. Skipping symbol uploads.");
+				onCompleted(0);
+				return;
+			}
+
+			var symbolUploadPath = GetSymUploaderPath();
+			if (!File.Exists(symbolUploadPath) && !DownloadSymbolUpload(symbolUploadPath))
+			{
+				onCompleted(-1);
+				return;
+			}
+
+			var version = string.IsNullOrEmpty(options.Version) ? Application.version : options.Version;
+			var application = string.IsNullOrEmpty(options.Application) ? Application.productName : options.Application;
+
+			var symUploadProcessInfo = new ProcessStartInfo
+			{
+				FileName = symbolUploadPath,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				Arguments = $"--database {options.Database} --application \"{application}\" " +
+					$"--version \"{version}\" --files \"{globPattern}\" --directory \"{artifactsDirPath}\""
+			};
+
+			symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_ID"] = clientId;
+			symUploadProcessInfo.EnvironmentVariables["SYMBOL_UPLOAD_CLIENT_SECRET"] = clientSecret;
+
+			if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android)
+			{
+				symUploadProcessInfo.Arguments += " --dumpSyms";
+			}
+
+			Process uploadSymProcess;
+			try
+			{
+				uploadSymProcess = Process.Start(symUploadProcessInfo);
+			}
+			catch (Exception ex)
+			{
+				Debug.LogError($"BugSplat. Failed to start {symbolUploadPath}. Error: {ex}");
+				onCompleted(-1);
+				return;
+			}
+
+			if (uploadSymProcess == null)
+			{
+				onCompleted(-1);
+				return;
+			}
+
+			Debug.Log(uploadSymProcess.StandardOutput.ReadToEnd());
+
+			uploadSymProcess.WaitForExit();
+
+			onCompleted(uploadSymProcess.ExitCode);
+		}
+
+		private static bool DownloadSymbolUpload(string destinationPath)
+		{
+			var variant = Path.GetFileName(destinationPath);
+			var fileUrl = $"https://app.bugsplat.com/download/{variant}";
+
+			try
+			{
+				Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+
+				using (var client = new WebClient())
+				{
+					Debug.Log($"BugSplat. Downloading {variant} to {destinationPath}");
+
+					client.DownloadFile(fileUrl, destinationPath);
+
+					if (File.Exists(destinationPath))
+					{
+						Debug.Log($"BugSplat. {variant} downloaded successfully to {destinationPath}");
+					}
+					else
+					{
+						Debug.LogError($"BugSplat. Could not download {variant}");
+						return false;
+					}
+				}
+			}
+			catch (WebException ex)
+			{
+				Debug.LogError($"BugSplat. Failed to download file from {fileUrl}. Error: {ex.Message}");
+				return false;
+			}
+			catch (Exception ex)
+			{
+				Debug.LogError($"BugSplat. Unexpected error during file download. Error: {ex}");
 				return false;
 			}
 
-			Debug.Log($"BugSplat. Successfully made {destinationPath} executable. Output: {output}");
-		}
-		catch (Exception ex)
-		{
-			Debug.LogError($"BugSplat. Error setting executable permission for {destinationPath}. Error: {ex}");
-			return false;
-		}
+			if (Application.platform == RuntimePlatform.WindowsEditor)
+			{
+				return true;
+			}
 
-		return true;
+			try
+			{
+				var absolutePath = Path.GetFullPath(destinationPath);
+
+				// Run chmod +x to make the file executable
+				var process = new Process();
+				process.StartInfo.FileName = "chmod";
+				process.StartInfo.Arguments = $"+x \"{absolutePath}\"";
+				process.StartInfo.UseShellExecute = false;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.RedirectStandardError = true;
+				process.Start();
+
+				var output = process.StandardOutput.ReadToEnd();
+				var error = process.StandardError.ReadToEnd();
+				process.WaitForExit();
+
+				if (process.ExitCode != 0)
+				{
+					Debug.LogError($"BugSplat. Failed to make {destinationPath} executable. Error: {error}");
+					return false;
+				}
+
+				Debug.Log($"BugSplat. Successfully made {destinationPath} executable. Output: {output}");
+			}
+			catch (Exception ex)
+			{
+				Debug.LogError($"BugSplat. Error setting executable permission for {destinationPath}. Error: {ex}");
+				return false;
+			}
+
+			return true;
+		}
 	}
 }

--- a/Runtime/Manager/BugSplatRef.cs
+++ b/Runtime/Manager/BugSplatRef.cs
@@ -1,17 +1,19 @@
 using System;
-using BugSplatUnity;
 
-public class BugSplatRef
+namespace BugSplatUnity.Runtime.Manager
 {
-    public BugSplat BugSplat { get; set; }
-
-    public BugSplatRef(BugSplat bugsplat)
+    internal class BugSplatRef
     {
-        if (bugsplat == null)
-        {
-            throw new ArgumentException("BugSplat error: BugSplat instance is null! BugSplatRef will not be initialized.");
-        }
+        public BugSplat BugSplat { get; }
 
-        BugSplat = bugsplat;
+        public BugSplatRef(BugSplat bugsplat)
+        {
+            if (bugsplat == null)
+            {
+                throw new ArgumentException("BugSplat error: BugSplat instance is null! BugSplatRef will not be initialized.");
+            }
+
+            BugSplat = bugsplat;
+        }
     }
 }

--- a/Samples~/my-unity-crasher/Scripts/BugSplatCube.cs
+++ b/Samples~/my-unity-crasher/Scripts/BugSplatCube.cs
@@ -1,10 +1,13 @@
 using UnityEngine;
 
-public class BugSplatCube : MonoBehaviour
+namespace Crasher
 {
-    void Update()
+    public class BugSplatCube : MonoBehaviour
     {
-        // Rotate slowly, but menacingly
-        transform.Rotate(new Vector3(0, 0, -0.2f));
+        void Update()
+        {
+            // Rotate slowly, but menacingly
+            transform.Rotate(new Vector3(0, 0, -0.2f));
+        }
     }
 }

--- a/Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs
+++ b/Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs
@@ -5,56 +5,59 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-public class BugSplatSettings : MonoBehaviour
+namespace Crasher
 {
-    BugSplat bugsplat;
-
-    // Start is called before the first frame update
-    void Start()
+    public class BugSplatSettings : MonoBehaviour
     {
-        var manager = FindAnyObjectByType<BugSplatManager>();
-        bugsplat = manager != null ? manager.BugSplat : null;
-        if (bugsplat == null)
+        BugSplat bugsplat;
+
+        // Start is called before the first frame update
+        void Start()
         {
-            Debug.LogError("[BugSplat] BugSplatManager not found in scene. Attributes and settings will not be applied.");
-            return;
-        }
-
-        bugsplat.Attributes.Add("OS", SystemInfo.operatingSystem);
-        bugsplat.Attributes.Add("CPU", SystemInfo.processorType);
-        bugsplat.Attributes.Add("MEMORY", $"{SystemInfo.systemMemorySize} MB");
-        bugsplat.Attributes.Add("GPU", SystemInfo.graphicsDeviceName);
-        bugsplat.Attributes.Add("GPU MEMORY", $"{SystemInfo.graphicsMemorySize} MB");
-        bugsplat.Description = "Overridden description from BugSplatSettings.";
-        bugsplat.Notes = "Overridden notes field from BugSplatSettings.";
-        bugsplat.User = "Fred";
-        bugsplat.Email = "fred@bugsplat.com";
-
-        if (!string.IsNullOrEmpty(Application.consoleLogPath))
-            bugsplat.AttachNativeLogFile(Application.consoleLogPath);
-
-        var lastPost = new DateTime(0);
-        bugsplat.ShouldPostException = (ex) =>
-        {
-            var now = DateTime.Now;
-
-            // Set to a long TimeSpan for demonstration purposes
-            // In production BugSplat recommends 3 seconds between posts
-            if (now - lastPost < TimeSpan.FromSeconds(7))
+            var manager = FindAnyObjectByType<BugSplatManager>();
+            bugsplat = manager != null ? manager.BugSplat : null;
+            if (bugsplat == null)
             {
-                Debug.LogWarning("ShouldPostException returns false in BugSplatSettings. Skipping BugSplat report...");
-                return false;
+                Debug.LogError("[BugSplat] BugSplatManager not found in scene. Attributes and settings will not be applied.");
+                return;
             }
 
-            Debug.Log("ShouldPostException returns true in BugSplatSettings. Posting BugSplat report...");
-            lastPost = now;
-            return true;
-        };
-    }
+            bugsplat.Attributes.Add("OS", SystemInfo.operatingSystem);
+            bugsplat.Attributes.Add("CPU", SystemInfo.processorType);
+            bugsplat.Attributes.Add("MEMORY", $"{SystemInfo.systemMemorySize} MB");
+            bugsplat.Attributes.Add("GPU", SystemInfo.graphicsDeviceName);
+            bugsplat.Attributes.Add("GPU MEMORY", $"{SystemInfo.graphicsMemorySize} MB");
+            bugsplat.Description = "Overridden description from BugSplatSettings.";
+            bugsplat.Notes = "Overridden notes field from BugSplatSettings.";
+            bugsplat.User = "Fred";
+            bugsplat.Email = "fred@bugsplat.com";
 
-    // Update is called once per frame
-    void Update()
-    {
+            if (!string.IsNullOrEmpty(Application.consoleLogPath))
+                bugsplat.AttachNativeLogFile(Application.consoleLogPath);
+
+            var lastPost = new DateTime(0);
+            bugsplat.ShouldPostException = (ex) =>
+            {
+                var now = DateTime.Now;
+
+                // Set to a long TimeSpan for demonstration purposes
+                // In production BugSplat recommends 3 seconds between posts
+                if (now - lastPost < TimeSpan.FromSeconds(7))
+                {
+                    Debug.LogWarning("ShouldPostException returns false in BugSplatSettings. Skipping BugSplat report...");
+                    return false;
+                }
+
+                Debug.Log("ShouldPostException returns true in BugSplatSettings. Posting BugSplat report...");
+                lastPost = now;
+                return true;
+            };
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
         
+        }
     }
 }

--- a/Samples~/my-unity-crasher/Scripts/LockOrientation.cs
+++ b/Samples~/my-unity-crasher/Scripts/LockOrientation.cs
@@ -1,11 +1,14 @@
 using UnityEngine;
 
-public class LockOrientation : MonoBehaviour
+namespace Crasher
 {
-    void Start()
+    public class LockOrientation : MonoBehaviour
     {
-        Screen.autorotateToPortrait = false;
-        Screen.autorotateToPortraitUpsideDown = false;
-        Screen.orientation = ScreenOrientation.AutoRotation;
+        void Start()
+        {
+            Screen.autorotateToPortrait = false;
+            Screen.autorotateToPortraitUpsideDown = false;
+            Screen.orientation = ScreenOrientation.AutoRotation;
+        }
     }
 }

--- a/Tests/Runtime/Manager/BugSplatRefTest.cs
+++ b/Tests/Runtime/Manager/BugSplatRefTest.cs
@@ -1,3 +1,4 @@
+using BugSplatUnity.Runtime.Manager;
 using NUnit.Framework;
 using System;
 


### PR DESCRIPTION
Closes #155

Public types declared in the global namespace are injected into the global scope of every project that installs the package, so `com.bugsplat.unity`'s names compete with the consumer's own. This moves all of them into the package's namespaces. Breaking-window item: free while 5.0.0 is unreleased, expensive after it tags.

## Offenders

I re-scanned every `.cs` in the repo (not just `Editor/` and `Runtime/`) for public types declared outside a `namespace` block. Seven, not three:

| File | Type | Moved to |
| --- | --- | --- |
| `Editor/PostBuild.cs` | `BuildPostprocessors` | `BugSplatUnity.Editor` |
| `Editor/BugSplatOptionsEditor.cs` | `BugSplatOptionsEditor` | `BugSplatUnity.Editor` |
| `Editor/BugSplatSymbolUploadCredentials.cs` | `BugSplatSymbolUploadCredentials` | `BugSplatUnity.Editor` |
| `Runtime/Manager/BugSplatRef.cs` | `BugSplatRef` | `BugSplatUnity.Runtime.Manager` |
| `Samples~/my-unity-crasher/Scripts/BugSplatCube.cs` | `BugSplatCube` | `Crasher` |
| `Samples~/my-unity-crasher/Scripts/BugSplatSettings.cs` | `BugSplatSettings` | `Crasher` |
| `Samples~/my-unity-crasher/Scripts/LockOrientation.cs` | `LockOrientation` | `Crasher` |

**The issue's list was incomplete.** It named `BuildPostprocessors`, `BugSplatOptionsEditor` and `BugSplatRef`; `BugSplatSymbolUploadCredentials` is a fourth package type the audit missed — it postdates the audit, having arrived with the symbol-upload credentials work. It is `public static` in the global namespace, so it belongs in the same fix.

The three sample scripts are the same defect one step removed: `Samples~` is excluded from compilation in the package, but on **Import** Unity copies it into the consumer's `Assets/`, where the scripts compile into `Assembly-CSharp` and `BugSplatSettings`/`LockOrientation` become global names in the consumer's own project. Their three siblings (`CrashScenarios`, `CrashScenarioMenu`, `FeedbackPopup`) already declare `namespace Crasher`, so this just finishes what was started there. Say the word if you'd rather keep the samples out of this PR and I'll split them.

After the change, zero `.cs` files in the repo lack a namespace declaration.

## Namespaces chosen

Existing convention, verified by counting: 51 already-namespaced files, all under `BugSplatUnity.*`. The rule is `BugSplatUnity.Editor` for `Editor/`, `BugSplatUnity.Runtime.<Folder>` for `Runtime/<Folder>/`, `Crasher` for the sample. Each moved file adopts the namespace its own directory already uses — `Editor/BugSplatLinkXmlProcessor.cs`, `Editor/BugSplatSymbolUploadMenu.cs` and `Editor/WerRegistration.cs` are already `BugSplatUnity.Editor`; `Runtime/Manager/BugSplatManager.cs` and `Runtime/Manager/BackgroundLogMessageQueue.cs` are already `BugSplatUnity.Runtime.Manager`. No new namespaces were invented.

## One non-mechanical consequence: `UnityEditor.Editor`

```diff
-public class BugSplatOptionsEditor : Editor
+public class BugSplatOptionsEditor : UnityEditor.Editor
```

Inside `namespace BugSplatUnity.Editor`, the simple name `Editor` is resolved by walking enclosing namespace scopes, and the enclosing `BugSplatUnity` scope has a **member namespace** named `Editor`. Member lookup in a scope precedes that scope's using directives, so `Editor` would bind to the namespace and the compile would fail with CS0118 before `using UnityEditor;` was ever consulted. Spelling the base type in full is the fix. This is the only place in the diff where a name would have rebound.

I checked the reverse case too: no simple name used in the moved editor files collides with a member of `BugSplatUnity` (`BugSplat`, `ReportPostOptions`, `IReportPostOptions`, `FormDataParam`, and the `Runtime`/`Editor` namespaces). Notably `PostBuild.cs` has `using BugSplatDotNetStandard;` and never uses the bare name `BugSplat`, so `BugSplatUnity.BugSplat` does not silently steal it.

## #132 F8 — the public setter

F8: *"`BugSplatRef` sits in the global namespace with a public setter."*

```diff
-public class BugSplatRef
+internal class BugSplatRef
 {
-    public BugSplat BugSplat { get; set; }
+    public BugSplat BugSplat { get; }
```

The property is now get-only. The constructor null-checks its argument and then assigns, so a public setter let any caller put back exactly the `null` the constructor exists to reject — the invariant was unenforceable.

I also made the type `internal`, which goes one step past what #155 asks, on this reasoning: `BugSplatRef` is a pure implementation detail. Its only use in the package is a `private` field in `BugSplatManager`, no public API accepts or returns one, and no consumer can construct a useful one (it wraps a `BugSplat` they already hold). Namespacing it alone would have kept a type on the public surface that exists for nobody. The test assembly still reaches it through the `[assembly: InternalsVisibleTo("BugSplat.Unity.RuntimeTests")]` already declared in `Runtime/BugSplat.cs`. If you'd rather it stayed `public` in its new namespace, it's a one-word revert — but now is the window for it either way.

## How every reference site was verified

Grepped the whole repo — `Editor/`, `Runtime/`, `Tests/`, `Samples~/`, `*.md`, `*.asmdef`, `*.json`, `*.unity`, `*.asset`, `*.meta` — for all seven type names. Every hit and its resolution:

- `Editor/BugSplatSymbolUploadMenu.cs` — 14 references to `BugSplatSymbolUploadCredentials` and 2 to `BuildPostprocessors`. Already `namespace BugSplatUnity.Editor`, now the same namespace as both. **No change needed.**
- `Editor/PostBuild.cs` — 7 self-references plus `BugSplatSymbolUploadCredentials`. Same namespace. **No change needed.**
- `Runtime/Manager/BugSplatManager.cs` — `private BugSplatRef bugsplatRef` and `new BugSplatRef(bugsplat)`. Already `namespace BugSplatUnity.Runtime.Manager`. **No change needed** (and an `internal` type in a `private` field of a public class raises no accessibility error — the exposed `BugSplatManager.BugSplat` property is typed `BugSplat`, which stays public).
- `Tests/Runtime/Manager/BugSplatRefTest.cs` — 3 references. Different namespace, so this is **the one file that needed a new `using BugSplatUnity.Runtime.Manager;`**.
- No hits in `README.md`, `Samples~/my-unity-crasher/README.md` (its only mention is the filename `BugSplatSettings.cs`, still accurate), any `.asmdef`, or any serialized asset.

To prove the rest of the diff is inert, I diffed every changed file against `HEAD` with **all leading whitespace stripped and blank lines dropped**. The complete set of non-indentation changes across 8 files:

```
Editor/PostBuild.cs                        + namespace BugSplatUnity.Editor / { / }
Editor/BugSplatSymbolUploadCredentials.cs  + namespace BugSplatUnity.Editor / { / }
Editor/BugSplatOptionsEditor.cs            + namespace BugSplatUnity.Editor / { / }
                                           - : Editor  ->  + : UnityEditor.Editor
Runtime/Manager/BugSplatRef.cs             + namespace BugSplatUnity.Runtime.Manager / { / }
                                           - using BugSplatUnity;   (now redundant)
                                           - public class  ->  + internal class
                                           - { get; set; } ->  + { get; }
Samples~/.../BugSplatCube.cs               + namespace Crasher / { / }
Samples~/.../BugSplatSettings.cs           + namespace Crasher / { / }
Samples~/.../LockOrientation.cs            + namespace Crasher / { / }
Tests/.../BugSplatRefTest.cs               + using BugSplatUnity.Runtime.Manager;
```

Nothing else moved. `PostBuild.cs`'s CRLF line endings are preserved, per-file tab-vs-space indentation is preserved, and `#if`/`#elif`/`#endif` stay at column 0, matching how `CrashScenarios.cs` and `BugSplat.cs` already format directives inside a namespace.

## Serialization safety

- **No file was renamed or moved, and no `.meta` file was touched** — `git status` lists 8 modified `.cs` files and nothing else. Unity serializes `MonoBehaviour`/`ScriptableObject` references by the script's `.meta` GUID, not by type name, so scene and prefab references survive a namespace change unchanged.
- Confirmed empirically: all 12 `m_Script` entries in `Samples~/my-unity-crasher/Scenes/Sample.unity` are `{fileID: 11500000, guid: ..., type: 3}`. There is not one name-based script reference in the repo.
- **No name-based type lookup anywhere.** Grepped for `Type.GetType`, `GetComponent("`, `AddComponent("` — zero hits. `Runtime/link.xml` names one type (`BugSplatUnity.Runtime.Reporter.BugSplatResponse`), untouched by this PR and already correct.
- None of the four package offenders is a `MonoBehaviour` or `ScriptableObject` in the first place: `BugSplatRef` is a plain class, `BuildPostprocessors` and `BugSplatSymbolUploadCredentials` are static helpers, `BugSplatOptionsEditor` derives from `UnityEditor.Editor`. Only the three sample scripts are `MonoBehaviour`s, and those are the GUID case above.

## Attribute-driven discovery

Each moved editor type is found by attribute scan over editor assemblies, never by namespace, so all of it keeps working:

- `BuildPostprocessors.OnPostprocessBuild` — `[PostProcessBuild(1)]`; Unity scans editor assemblies for static methods carrying the attribute.
- `BugSplatOptionsEditor` — `[CustomEditor(typeof(BugSplatOptions))]`; Unity's `CustomEditorAttributes` indexes types deriving from `Editor` that carry the attribute, keyed by the inspected type, not by the editor's own name.
- `BugSplatSymbolUploadCredentials` — no discovery at all; called directly from `PostBuild.cs` and `BugSplatSymbolUploadMenu.cs`, both now in the same namespace.
- `BugSplatSymbolUploadMenu`'s `[MenuItem]` entries and `BugSplatLinkXmlProcessor`'s `IUnityLinkerProcessor` are already namespaced and unchanged.

## asmdef `rootNamespace`

`Editor/BugSplat.Unity.Editor.asmdef` and `Tests/BugSplat.Unity.RuntimeTests.asmdef` both set `"rootNamespace": ""`; `Runtime/BugSplat.Unity.Runtime.asmdef` omits the key. `rootNamespace` only seeds the namespace Unity writes into **newly created** script files from the editor — it is not passed to the compiler and does not affect resolution — so it has no interaction with this change and no asmdef needed editing. Worth noting the empty value is what let these files be created in the global namespace in the first place; setting it to `BugSplatUnity` would nudge future files in the right direction, but that's editor UX and out of scope here.

## Verification / CI

No local Unity install, so no local compile. Compensating checks, all done: the whitespace-stripped diff above (proves nothing but the wrapper changed), the re-scan for namespace-less files (now zero), the full-repo re-grep of all seven type names with each hit resolved individually, and the name-rebinding analysis that caught the `Editor` -> `UnityEditor.Editor` collision.

CI is the real gate, and it is **green**. Run [32321362278](https://github.com/BugSplat-Git/bugsplat-unity/actions/runs/32321362278) concluded `success`:

| Check | Result |
| --- | --- |
| `StandaloneLinux64` | pass (3m44s) |
| `StandaloneWindows64` | pass (3m07s) |
| `StandaloneOSX` | pass (3m13s) |
| `WebGL` | pass (3m46s) |
| `Compile iOS` | pass (2m40s) |
| `Compile Android` | pass (3m43s) |
| `Analyze (csharp)` / `Analyze (actions)` / `CodeQL` | pass |

Both assemblies compile and the test suite passes on every target, including the `UNITY_IOS` and `UNITY_ANDROID` branches of `PostBuild.cs` that only the compile checks reach.

Not touched: `CHANGELOG.md`. The 5.0.0 section looks to be written at release time — none of the last ten merged PRs, including breaking ones like #207, updated it — so I left it alone rather than diverge from that. Happy to add a `### Changed` entry if you'd prefer it recorded now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
