### PR TITLE
fix: show the BugSplat logo in the macOS crash dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Upgrading from 4.x? See [Migrating from 4.x](Documentation~/migrating-from-4x.md
 
 ### Fixed
 
+- The macOS crash dialog showed a drawn placeholder instead of the BugSplat logo. The dialog resolves its banner against the bundle its own class came from, which works for apps linking `BugSplat.framework` but not for Unity, which ships the SDK as a bare dylib with no resources. The macOS post-build step now copies `bugsplat-logo.png` into the player's `Contents/Resources`, where the lookup finds it.
 - Android native crash reporting was never actually enabled — the Android init branch never set the flag every native setter guards on, so all of them silently no-oped, including the attribute-sync callback. Runtime attributes, user, email, key, and notes now reach the native reporter.
 - `SetNativeKey` had no iOS or macOS branch, so `Key` never reached Apple native reports. Both now assign bugsplat-apple's `appKey` property directly.
 - `BugSplatOptions.Attributes` were never read by `CreateFromOptions`, so attributes authored on an options asset never reached a report.

--- a/Documentation~/macos.md
+++ b/Documentation~/macos.md
@@ -7,3 +7,5 @@ The bugsplat-unity plugin supports native crash reporting on macOS via [bugsplat
 To configure crash reporting for macOS, set the `UseNativeCrashReportingForMac` and `UploadDebugSymbolsForMac` properties to `true` on your `BugSplatOptions` asset. For IL2CPP builds, BugSplat will upload dSYMs and `LineNumberMappings.json` for full symbolication.
 
 `Player.log` is attached to native macOS crash reports when `CapturePlayerLog` is enabled on your `BugSplatOptions` asset.
+
+When `UseNativeCrashReportingForMac` is enabled, the post-build step also copies `bugsplat-logo.png` into the built player's `Contents/Resources`. The crash dialog looks its banner up in the app bundle, so without that file it falls back to a plain drawn logo. Xcode project exports are skipped — add the file to your Xcode target's resources yourself if you want the logo there.

--- a/Documentation~/macos.md
+++ b/Documentation~/macos.md
@@ -8,4 +8,4 @@ To configure crash reporting for macOS, set the `UseNativeCrashReportingForMac` 
 
 `Player.log` is attached to native macOS crash reports when `CapturePlayerLog` is enabled on your `BugSplatOptions` asset.
 
-When `UseNativeCrashReportingForMac` is enabled, the post-build step also copies `bugsplat-logo.png` into the built player's `Contents/Resources`. The crash dialog looks its banner up in the app bundle, so without that file it falls back to a plain drawn logo. Xcode project exports are skipped — add the file to your Xcode target's resources yourself if you want the logo there.
+When `UseNativeCrashReportingForMac` is enabled, the post-build step also copies `bugsplat-logo.png` into the built player's `Contents/Resources`. The crash dialog looks up its banner in the app bundle, so without that file it falls back to a plain drawn logo. Xcode project exports are skipped — add the file to your Xcode target's resources yourself if you want the logo there.

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -30,7 +30,8 @@ namespace BugSplatUnity.Editor
 	{
 		static string _platform;
 
-		// Resource name the macOS crash dialog looks up; the file has to keep this name in the player.
+		// On-disk filename to copy. The dialog resolves it by resource name - "bugsplat-logo",
+		// without the extension - so the base name is what has to survive into the player.
 		const string LogoFileName = "bugsplat-logo.png";
 
 		const string SymUploaderWindows = "symbol-upload-windows.exe";

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -30,6 +30,9 @@ namespace BugSplatUnity.Editor
 	{
 		static string _platform;
 
+		// Resource name the macOS crash dialog looks up; the file has to keep this name in the player.
+		const string LogoFileName = "bugsplat-logo.png";
+
 		const string SymUploaderWindows = "symbol-upload-windows.exe";
 		const string SymUploaderMacOS = "symbol-upload-macos";
 		const string SymUploaderLinux = "symbol-upload-linux";
@@ -87,7 +90,61 @@ namespace BugSplatUnity.Editor
 			}
 
 			if (target == BuildTarget.StandaloneOSX)
+			{
+				CopyMacCrashDialogLogo(pathToBuiltProject, options);
 				PostProcessMac(pathToBuiltProject, options);
+			}
+		}
+
+		/// <summary>
+		/// Puts the BugSplat logo where the macOS crash dialog can find it.
+		///
+		/// The dialog loads its banner with [[NSBundle bundleForClass:self] imageForResource:@"bugsplat-logo"].
+		/// An app that links BugSplat.framework resolves that inside the framework's own Resources, but Unity
+		/// ships the SDK as a bare dylib, which carries no resources of its own — so the lookup lands on the
+		/// player's bundle instead, misses, and the dialog silently falls back to a programmatically drawn
+		/// logo. Copying the framework's own PNG into the player's Resources is what makes the real one resolve.
+		/// </summary>
+		private static void CopyMacCrashDialogLogo(string pathToBuiltProject, BugSplatOptions options)
+		{
+			if (!options.UseNativeCrashReportingForMac)
+				return;
+
+			// An Xcode project export has no .app yet — Xcode assembles Contents/Resources at its own build time.
+			if (!pathToBuiltProject.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+			{
+				Debug.Log("BugSplat: Xcode project export detected, skipping the macOS crash dialog logo. Add bugsplat-logo.png to the Xcode target's resources to show it.");
+				return;
+			}
+
+			var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(BuildPostprocessors).Assembly);
+			var packageRoot = packageInfo?.resolvedPath ?? Path.GetFullPath(Path.Combine("Packages", "com.bugsplat.unity"));
+			var source = Path.Combine(
+				packageRoot, "Editor", "IOS", "Frameworks", "BugSplat.xcframework",
+				"macos-arm64_x86_64", "BugSplat.framework", "Versions", "A", "Resources", LogoFileName);
+
+			if (!File.Exists(source))
+			{
+				Debug.LogWarning($"BugSplat. Missing {source}. The macOS crash dialog will draw its fallback logo.");
+				return;
+			}
+
+			var resourcesDir = Path.Combine(pathToBuiltProject, "Contents", "Resources");
+			if (!Directory.Exists(resourcesDir))
+			{
+				Debug.LogWarning($"BugSplat. {resourcesDir} does not exist. The macOS crash dialog will draw its fallback logo.");
+				return;
+			}
+
+			try
+			{
+				File.Copy(source, Path.Combine(resourcesDir, LogoFileName), true);
+				Debug.Log($"BugSplat. Copied {LogoFileName} into the player's Resources so the macOS crash dialog shows the BugSplat logo.");
+			}
+			catch (Exception ex)
+			{
+				Debug.LogWarning($"BugSplat. Could not copy {LogoFileName} into the player: {ex.Message}. The macOS crash dialog will draw its fallback logo.");
+			}
 		}
 
 		// Zips a single file with the entry at the archive root and writes it to destZip.

--- a/Editor/PostBuild.cs
+++ b/Editor/PostBuild.cs
@@ -111,10 +111,15 @@ namespace BugSplatUnity.Editor
 			if (!options.UseNativeCrashReportingForMac)
 				return;
 
+			// Trailing separators are trimmed before the suffix test. Unity has never supplied one,
+			// but if it did the check would misfire on a real .app build - skipping the copy and
+			// logging an Xcode export as the reason, which is a poor way to discover the bug.
+			var builtAppPath = pathToBuiltProject.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
 			// An Xcode project export has no .app yet — Xcode assembles Contents/Resources at its own build time.
-			if (!pathToBuiltProject.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+			if (!builtAppPath.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
 			{
-				Debug.Log("BugSplat: Xcode project export detected, skipping the macOS crash dialog logo. Add bugsplat-logo.png to the Xcode target's resources to show it.");
+				Debug.Log($"BugSplat: Xcode project export detected, skipping the macOS crash dialog logo. Add {LogoFileName} to the Xcode target's resources to show it.");
 				return;
 			}
 
@@ -130,7 +135,7 @@ namespace BugSplatUnity.Editor
 				return;
 			}
 
-			var resourcesDir = Path.Combine(pathToBuiltProject, "Contents", "Resources");
+			var resourcesDir = Path.Combine(builtAppPath, "Contents", "Resources");
 			if (!Directory.Exists(resourcesDir))
 			{
 				Debug.LogWarning($"BugSplat. {resourcesDir} does not exist. The macOS crash dialog will draw its fallback logo.");


### PR DESCRIPTION
## The symptom

Every Unity macOS player shows a plain drawn logo in the BugSplat crash dialog instead of the real BugSplat logo.

## Why

The dialog resolves its banner image against the bundle its own class came from:

```objc
NSBundle *bundle = [NSBundle bundleForClass:[self class]];
NSImage *bundledLogo = [bundle imageForResource:@"bugsplat-logo"];
if (bundledLogo) return bundledLogo;
return [self createProgrammaticBugSplatLogo];   // <- what Unity has always hit
```

An app that links `BugSplat.framework` resolves that inside the framework's own `Resources`, which contains `bugsplat-logo.png`. Unity ships the SDK as a bare `BugSplat-macOS.dylib`, which carries no resources at all — so the lookup lands on the player's bundle, finds nothing, and silently falls back.

This is a packaging gap on our side, not a bug in bugsplat-apple: the vendored dylib is byte-identical to the 3.5.0 release asset, and the logo lives in the framework's `Resources`, which a standalone dylib has no equivalent of.

## The fix

The macOS post-build step copies `bugsplat-logo.png` into the built player's `Contents/Resources`, which is exactly where that lookup resolves — whether `bundleForClass:` returns the main bundle or the enclosing `.app`, both land in the same place.

No new binary is vendored. The PNG is read out of the `BugSplat.framework` macOS slice already in the package, so the image the dialog renders is the same one it would have used natively.

Details worth noting for review:

- Gated on `UseNativeCrashReportingForMac` — no native reporting, no dialog, nothing to do.
- Deliberately **not** inside `PostProcessMac`, which returns early when `UploadDebugSymbolsForMac` is off. The logo has nothing to do with symbol upload, and burying it there would make it silently depend on an unrelated setting.
- Xcode project exports are skipped and say so, since Xcode assembles `Contents/Resources` at its own build time.
- Every failure path (missing source, missing `Resources`, copy error) warns and continues rather than failing the build. The worst case is the fallback logo that ships today.
- Sourced via `PackageInfo.FindForAssembly(...).resolvedPath`, the same package-root resolution the Windows `Support~` copy already uses.

## Verification

The post-build path was exercised by building the `my-unity-crasher` sample as a macOS IL2CPP player against this branch's package.

Not verified: nobody has yet triggered a native crash and relaunched to see the dialog render the real logo on screen. The lookup path is confirmed by inspection of the 3.5.0 dialog source and the framework's `Resources` layout, but the rendered result is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCtsoKMLq2WeYvsPFivVAA