### PR TITLE
fix: attach Player.log to native iOS crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Upgrading from 4.x? See [Migrating from 4.x](Documentation~/migrating-from-4x.md
 
 ### Fixed
 
+- `CapturePlayerLog` never reached the iOS native reporter, so native iOS crash reports carried no `Player.log`. The attachment delegate was installed before `-start`, but the log path was only registered after the constructor returned — by which point `-start` had already processed the previous session's pending reports and asked the delegate for attachments, with nothing tracked. iOS now registers the log before `-start`, as macOS already did.
 - The macOS crash dialog showed a drawn placeholder instead of the BugSplat logo. The dialog resolves its banner against the bundle its own class came from, which works for apps linking `BugSplat.framework` but not for Unity, which ships the SDK as a bare dylib with no resources. The macOS post-build step now copies `bugsplat-logo.png` into the player's `Contents/Resources`, where the lookup finds it.
 - Android native crash reporting was never actually enabled — the Android init branch never set the flag every native setter guards on, so all of them silently no-oped, including the attribute-sync callback. Runtime attributes, user, email, key, and notes now reach the native reporter.
 - `SetNativeKey` had no iOS or macOS branch, so `Key` never reached Apple native reports. Both now assign bugsplat-apple's `appKey` property directly.

--- a/Documentation~/ios.md
+++ b/Documentation~/ios.md
@@ -8,6 +8,8 @@ When native crash reporting is enabled, BugSplat automatically disables Unity's 
 
 For IL2CPP builds, BugSplat will also upload `LineNumberMappings.json` alongside dSYMs. This enables BugSplat to map IL2CPP-generated C++ symbols back to original C# method names, file names, and line numbers.
 
+`Player.log` is attached to native iOS crash reports when `CapturePlayerLog` is enabled on your `BugSplatOptions` asset.
+
 ## Hang Detection
 
 When `UseNativeCrashReportingForIos` is enabled, BugSplat also detects fatal main-thread hangs. No additional configuration is required. If the main thread stalls past the detection threshold and the app is subsequently terminated without recovering — by the OS watchdog at launch/resume, or by the user force-quitting — BugSplat uploads an `App Hang (Fatal)` report on the next launch. Hangs the app recovers from are not reported. Detection is suppressed while a debugger is attached, so test hang reporting on a build run without the Xcode debugger.

--- a/Documentation~/ios.md
+++ b/Documentation~/ios.md
@@ -8,7 +8,7 @@ When native crash reporting is enabled, BugSplat automatically disables Unity's 
 
 For IL2CPP builds, BugSplat will also upload `LineNumberMappings.json` alongside dSYMs. This enables BugSplat to map IL2CPP-generated C++ symbols back to original C# method names, file names, and line numbers.
 
-`Player.log` is attached to native iOS crash reports when `CapturePlayerLog` is enabled on your `BugSplatOptions` asset.
+`Player.log` is attached to native iOS crash reports when both `UseNativeCrashReportingForIos` and `CapturePlayerLog` are enabled on your `BugSplatOptions` asset. Managed .NET exception reports attach it through the reporter instead, so they are unaffected by the native setting.
 
 ## Hang Detection
 

--- a/Documentation~/macos.md
+++ b/Documentation~/macos.md
@@ -6,7 +6,7 @@ The bugsplat-unity plugin supports native crash reporting on macOS via [bugsplat
 
 To configure crash reporting for macOS, set the `UseNativeCrashReportingForMac` and `UploadDebugSymbolsForMac` properties to `true` on your `BugSplatOptions` asset. For IL2CPP builds, BugSplat will upload dSYMs and `LineNumberMappings.json` for full symbolication.
 
-`Player.log` is attached to native macOS crash reports when `CapturePlayerLog` is enabled on your `BugSplatOptions` asset.
+`Player.log` is attached to native macOS crash reports when both `UseNativeCrashReportingForMac` and `CapturePlayerLog` are enabled on your `BugSplatOptions` asset. Managed .NET exception reports attach it through the reporter instead, so they are unaffected by the native setting.
 
 When `UseNativeCrashReportingForMac` is enabled, the post-build step also copies `bugsplat-logo.png` into the built player's `Contents/Resources`. The crash dialog looks up its banner in the app bundle, so without that file it falls back to a plain drawn logo. Xcode project exports are skipped — add the file to your Xcode target's resources yourself if you want the logo there.
 

--- a/Editor/IOS/ObjC/BugSplatBridge.mm
+++ b/Editor/IOS/ObjC/BugSplatBridge.mm
@@ -116,7 +116,7 @@ extern "C" {
 	}
 
 	void _startBugSplat(const char* database, const char* application, const char* version,
-	                    int autoSubmitCrashReport, int autoSubmitFatalHangReport) {
+	                    const char* logFilePath, int autoSubmitCrashReport, int autoSubmitFatalHangReport) {
 		BugSplat *bugsplat = [BugSplat shared];
 		bugsplat.bugSplatDatabase = createNSStringFrom(database);
 		bugsplat.applicationName = createNSStringFrom(application);
@@ -141,8 +141,10 @@ extern "C" {
 		// _startBugSplat is only invoked when UseNativeCrashReportingForIos is enabled.
 		// Must be set before -start, which Unity calls on the main thread.
 		bugsplat.enableHangDetection = YES;
-		// Set up the attachment delegate BEFORE start so it's available when
-		// pending crash reports are processed on launch.
+		// Track the log BEFORE start as well as the delegate. start processes the crash reports
+		// left by the previous session and asks the delegate for attachments while it does, so a
+		// path added afterwards arrives too late for the very reports it was meant to accompany.
+		AddLogFilePath(createNSStringFrom(logFilePath));
 		bugsplat.delegate = EnsureDelegate();
 		[bugsplat start];
 	}

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -358,8 +358,17 @@ namespace BugSplatUnity
 #elif UNITY_IOS && !UNITY_EDITOR
             if (useNativeLibIos)
             {
-                _startBugSplat(database, application, version, autoSubmit, autoSubmitHang);
+                // Same ordering constraint as macOS: the delegate is queried while start processes
+                // crash reports left by the previous session, so the player log has to be tracked
+                // before start rather than attached after it.
+                var logPath = capturePlayerLog ? consoleLogPath : null;
+                _startBugSplat(database, application, version, logPath ?? "", autoSubmit, autoSubmitHang);
                 nativeCrashReportingEnabled = true;
+
+                if (logPath != null)
+                {
+                    nativeAttachmentPaths.Add(logPath);
+                }
             }
 
             UseDotNetHandler(database, application, version, capturePlayerLog);
@@ -881,15 +890,9 @@ namespace BugSplatUnity
         }
 
 #if (UNITY_IOS || UNITY_STANDALONE_OSX) && !UNITY_EDITOR
-        // Both Apple bridges export the same symbols; only -start differs, because the macOS
-        // bridge needs the log path in hand before start scans the previous session's reports.
-#if UNITY_IOS
-        [DllImport("__Internal")]
-        static extern void _startBugSplat(string database, string application, string version, int autoSubmitCrashReport, int autoSubmitFatalHangReport);
-#else
+        // Both Apple bridges now export identical symbols with identical signatures.
         [DllImport("__Internal")]
         static extern void _startBugSplat(string database, string application, string version, string logFilePath, int autoSubmitCrashReport, int autoSubmitFatalHangReport);
-#endif
 
         [DllImport("__Internal")]
         static extern void _setNativeAttribute(string key, string value);

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -367,7 +367,13 @@ namespace BugSplatUnity
 
                 if (logPath != null)
                 {
-                    nativeAttachmentPaths.Add(logPath);
+                    // Uncontended - nothing else can reach this instance yet - but taken anyway so
+                    // "every mutation of nativeAttachmentPaths happens under its lock" holds without
+                    // exception. An invariant with two documented escapes is one nobody can audit.
+                    lock (nativeAttachmentPaths)
+                    {
+                        nativeAttachmentPaths.Add(logPath);
+                    }
                 }
             }
 
@@ -383,7 +389,13 @@ namespace BugSplatUnity
 
                 if (logPath != null)
                 {
-                    nativeAttachmentPaths.Add(logPath);
+                    // Uncontended - nothing else can reach this instance yet - but taken anyway so
+                    // "every mutation of nativeAttachmentPaths happens under its lock" holds without
+                    // exception. An invariant with two documented escapes is one nobody can audit.
+                    lock (nativeAttachmentPaths)
+                    {
+                        nativeAttachmentPaths.Add(logPath);
+                    }
                 }
             }
 


### PR DESCRIPTION
> Stacked on #230, which is stacked on #229. Retarget as those merge.

Closes the wiring half of #222 / #183.

## The bug

`CapturePlayerLog` never reached the iOS native reporter, so **native iOS crash reports have never carried `Player.log`** — despite the option defaulting to `true`.

The bridge installs the attachment delegate before `-start`, and its own comment says why:

```objc
// Set up the attachment delegate BEFORE start so it's available when
// pending crash reports are processed on launch.
bugsplat.delegate = EnsureDelegate();
[bugsplat start];
```

But the delegate serves attachments out of `LogFilePaths()`, and nothing had put the log there yet. The path was only registered later via `_attachNativeLogFile`, after the constructor returned. Meanwhile `SetNativePlayerLogAttachment` is called **only** in the Windows branch, and the macOS branch threads the path into `-start` — the iOS branch did neither.

Since native crash reports upload on the launch *after* the crash, attachments were requested at exactly the moment the list was guaranteed empty. Managed exception reports are unaffected — they attach the log through the .NET reporter.

## The fix

Pass the path into `_startBugSplat` and `AddLogFilePath` it before `-start`, which is what macOS already did:

```csharp
// Same ordering constraint as macOS: the delegate is queried while start processes
// crash reports left by the previous session, so the player log has to be tracked
// before start rather than attached after it.
var logPath = capturePlayerLog ? consoleLogPath : null;
_startBugSplat(database, application, version, logPath ?? "", autoSubmit, autoSubmitHang);
```

Both Apple `-start` functions now take identical arguments, so the last platform-specific `DllImport` in the Apple block collapses as well — finishing the symbol unification #230 started.

## Note on #222 and #183

Both describe iOS `AttachNativeLogFile` as "an empty stub." That is no longer true — #225 implemented it. What remained broken was that nothing ever called it for the player log, and that calling it post-construction was too late regardless. That is what this fixes; the issues should be rescoped or closed rather than left as written.

## Verification

- iOS bridge **compiled against the vendored xcframework** with the iOS SDK — clean under both ARC and manual retain/release, with `-Wundeclared-selector` on. This is the check CI cannot do (it runs Unity on Linux with no Xcode), and it is what #200 flags as the highest-risk gap in the release sweep.
- macOS player built and run to confirm the now-shared start signature did not regress it: `errors=0`, hang detection still arms, no exceptions.

Not verified: no iOS device build, so an actual iOS crash report has not been inspected for the attachment. Worth confirming during #200 session 6 — and note bugsplat-apple historically limited iOS reports to a single attachment, which #225 claims to have addressed but which has not been exercised on a real report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCtsoKMLq2WeYvsPFivVAA