### PR TITLE
chore: remove the orphaned UNITY_WSA player-log branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Upgrading from 4.x? See [Migrating from 4.x](Documentation~/migrating-from-4x.md
 
 ### Removed
 
+- The orphaned `UNITY_WSA` player-log branch in `DotNetStandardExceptionReporter`. It was the only WSA/UWP code in the package — no options, no README claim, no platform-support row, no CI target — so it read as support that did not exist. Removing it in a release that is already breaking avoids either a needless break later or carrying dead code for two more versions ([#196](https://github.com/BugSplat-Git/bugsplat-unity/issues/196)).
+
 - **Breaking:** `WindowsReporter` and `INativeCrashReporter`. Unity's `CrashReporting.crashReportFolder` minidumps are no longer read or uploaded — native Windows crashes are captured by bugsplat-windows instead.
 - **Breaking:** `PostAllCrashes`, `PostCrash`, and `PostMostRecentCrash`. Unsent native crash reports upload automatically at startup, so there is nothing to call at launch. Delete any calls to these methods.
 - **Breaking:** `BugSplatOptions.SymbolUploadClientId` and `BugSplatOptions.SymbolUploadClientSecret`. Set credentials from **BugSplat > Symbol Upload > Set Credentials**, or with the environment variables in CI.

--- a/Documentation~/usage.md
+++ b/Documentation~/usage.md
@@ -182,7 +182,7 @@ private void OpenUrl(string url)
 {
     var escaped = url.Replace("?", "\\?").Replace("&", "\\&").Replace(" ", "%20").Replace("!", "\\!");
 
-#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
     Process.Start(url);
 #elif UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
     Process.Start("open", escaped);

--- a/Runtime/Reporter/DotNetStandardExceptionReporter.cs
+++ b/Runtime/Reporter/DotNetStandardExceptionReporter.cs
@@ -148,7 +148,7 @@ namespace BugSplatUnity.Runtime.Reporter
 
             if (clientSettings.CapturePlayerLog)
             {
-#if  UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
                 var localLowId = new Guid("A520A1A4-1780-4FF6-BD18-167343C5AF16");
                 var localLow = GetKnownFolderPath(localLowId);
                 var playerLogFilePath = Path.Combine(localLow, Application.companyName, Application.productName, "Player.log");
@@ -190,25 +190,6 @@ namespace BugSplatUnity.Runtime.Reporter
 #elif UNITY_STANDALONE_LINUX
                 var home = Environment.GetEnvironmentVariable("HOME");
                 var playerLogFilePath = Path.Combine(home, ".config", "unity3d", Application.companyName, Application.productName, "Player.log");
-                var playerLogFileInfo = new FileInfo(playerLogFilePath);
-                if (playerLogFileInfo.Exists)
-                {
-                    try
-                    {
-                        AddLogTailAttachment(playerLogFileInfo, options, tempFiles);
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogError($"BugSplat error: Could not copy log tail to temp file {ex}");
-                    }
-                }
-                else
-                {
-                    Debug.Log($"BugSplat info: Could not find {playerLogFileInfo.FullName}, skipping...");
-                }
-#elif UNITY_WSA
-                var tempState = Application.temporaryCachePath;
-                var playerLogFilePath = Path.Combine(tempState, "UnityPlayer.log");
                 var playerLogFileInfo = new FileInfo(playerLogFilePath);
                 if (playerLogFileInfo.Exists)
                 {


### PR DESCRIPTION
Closes #196, moved from 5.2.0 to 5.0.0.

Independent of the #229 → #230 → #231 → #232 → #235 stack — nothing in it touches this file, so this branches from `main` and can merge in parallel.

## What was there

`DotNetStandardExceptionReporter` had a `#elif UNITY_WSA` branch reading `UnityPlayer.log` from `temporaryCachePath`. It was the **only** WSA/UWP code in the package:

- no `BugSplatOptions` field
- no README claim or platform-support table row
- no CI target (CI builds Linux, Windows, macOS, WebGL)
- nothing in the sample

A single conditional branch is not support, but it reads like the beginning of some — which is worse than nothing being there, because it invites the assumption that the platform is handled.

## Why now rather than 5.2.0

#196 was scheduled for 5.2.0. Removing a code path is a breaking change in the strictest sense, even for a platform nobody claims to support. **5.0.0 is already breaking**, so it is free here; in 5.2.0 it is either a needless break in a minor version or two more releases of carrying dead code.

## Behaviour

WSA builds now fall to the existing `#else`, which logs that `CapturePlayerLog` is not implemented on the platform. That was already true — it is just said out loud instead of half-implemented.

## Also

- Dropped `UNITY_WSA` from the conditional-compilation example in `usage.md`. It is an illustrative snippet rather than a support claim, but pointing readers at a platform the package has no code for is worse than the shorter example.
- Fixed a double space in the `#if  UNITY_STANDALONE_WIN` directive on the same chain.

## Verification, and its limit

macOS IL2CPP player builds clean, `errors=0`.

Being precise about what that does and does not prove: a macOS build never compiled the `UNITY_WSA` branch, so this confirms the surrounding chain is still well-formed, not that a WSA build is unaffected. There is no WSA build to be unaffected — which is the entire point. CI would not have caught a WSA break either, since no CI target builds it.

Net: **-21 / +4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCtsoKMLq2WeYvsPFivVAA