### PR TITLE
docs: separate managed and native attachments in the API reference

### DIFF
--- a/Documentation~/api.md
+++ b/Documentation~/api.md
@@ -29,7 +29,7 @@ The following API methods are available to help you customize BugSplat to fit yo
 | CapturePlayerLog| Should BugSplat upload Player.log when Post is called. Enabled by default — see [Player.log and privacy](#playerlog-and-privacy) |
 | CaptureScreenshots | Should BugSplat a screenshot and upload it when Post is called |
 | PostExceptionsInEditor | Should BugSplat upload exceptions when in editor. Defaults to false so play mode exceptions stay out of your database |
-| PersistentDataFileAttachmentPaths |  Paths to files (relative to Application.persistentDataPath) to upload with each report |
+| PersistentDataFileAttachmentPaths | Paths to files (relative to Application.persistentDataPath) to attach to reports posted from managed code — exception reports, feedback, and minidumps you post yourself. Native crash reports are assembled by the platform's crash reporter and never see this list; attach files to those with [AttachNativeLogFile](#attaching-files-to-native-crash-reports) |
 | UseNativeCrashReportingForWindows | Use native crash reporting library (bugsplat-windows) for Windows builds. Works with both Mono and IL2CPP |
 | UploadDebugSymbolsForWindows | Upload `.pdb`, `.dll` and `.exe` symbols to BugSplat for Windows builds. `true` by default — Windows has always uploaded automatically, so defaulting it off would silently stop existing projects symbolicating. Also needs **Copy PDB Files** and a Windows editor |
 | WindowsShowCrashDialog | Show the BugSplat crash dialog when a native crash occurs on Windows (default). When disabled, crash reports are sent silently |
@@ -56,12 +56,19 @@ bugsplat.CapturePlayerLog = false;
 
 ## Attaching Files to Native Crash Reports
 
-`Attachments` adds files to managed posts. A native crash is captured and uploaded by the platform's crash reporter, which never sees that list, so files for native reports are attached with `AttachNativeLogFile`:
+`Attachments` — and the `PersistentDataFileAttachmentPaths` on your options asset, which populates it — adds files to managed posts. A native crash is captured and uploaded by the platform's crash reporter, which never sees that list, so files for native reports are attached with `AttachNativeLogFile`:
 
 ```cs
 bugsplat.AttachNativeLogFile("/path/to/support.log");
 bugsplat.DetachNativeLogFile("/path/to/support.log");
 ```
+
+The separation runs both ways: a file attached with `AttachNativeLogFile` reaches native crash reports only, and never appears on a managed exception report or a feedback post. Nothing bridges the two lists, so a file you want on both kinds of report has to be registered with both mechanisms.
+
+| Mechanism | Reaches | Does not reach |
+|---|---|---|
+| `Attachments`, `PersistentDataFileAttachmentPaths` | Managed exception reports, feedback, and minidumps you post with `Post(FileInfo)` | Native crash reports |
+| `AttachNativeLogFile` | Native crash reports on Windows, macOS, and iOS | Managed exception reports and feedback |
 
 Attaching is **additive and idempotent**. Every attached file is included in a native report, attaching one file never displaces another, and attaching the same file twice attaches it once. Paths are resolved to full paths before they are compared — and compared case-insensitively on Windows — so `"logs/support.log"` and `"C:\Game\Logs\Support.log"` are recognized as the file they name rather than as new attachments. `DetachNativeLogFile` removes one file and leaves the rest attached.
 

--- a/Runtime/BugSplat.cs
+++ b/Runtime/BugSplat.cs
@@ -23,7 +23,9 @@ namespace BugSplatUnity
     public class BugSplat
     {
         /// <summary>
-        /// A list of files to be uploaded every time Post is called
+        /// A list of files to be uploaded every time Post is called. These files reach reports posted from
+        /// managed code only — a native crash is captured and uploaded by the platform's crash reporter,
+        /// which never sees this list. Use AttachNativeLogFile to attach files to native crash reports.
         /// </summary>
         public List<FileInfo> Attachments
         {

--- a/Runtime/Client/BugSplatOptions.cs
+++ b/Runtime/Client/BugSplatOptions.cs
@@ -63,7 +63,7 @@ namespace BugSplatUnity.Runtime.Client
 		[Tooltip("Should BugSplat upload exceptions when in editor. Off by default so play mode exceptions stay out of your database.")]
 		public bool PostExceptionsInEditor;
 
-		[Tooltip("Paths to files (relative to Application.persistentDataPath) to upload with each report.")]
+		[Tooltip("Paths to files (relative to Application.persistentDataPath) to attach to reports posted from managed code - exception reports, feedback, and minidumps you post yourself. Native crash reports are assembled by the platform's crash reporter and never see this list, so attach files to those with AttachNativeLogFile in code.")]
 		public List<string> PersistentDataFileAttachmentPaths;
 
 		[Header("Windows")]


### PR DESCRIPTION
Closes #242. Docs only — no behavior change, and no runtime code was touched.

## The problem

`PersistentDataFileAttachmentPaths` was documented as "Paths to files (relative to `Application.persistentDataPath`) to upload with each report", in both `api.md` and the Inspector tooltip. "Each report" reads as *every* report the SDK sends. It isn't. Configure a file there, then test with a native crash — the obvious way to test a crash reporter — and nothing arrives, with no explanation anywhere. That is exactly how it was hit during the 5.0.0 smoke test (#200).

## What the source actually does

Verified by reading both chains rather than trusting the issue's summary:

**Managed** — `BugSplatOptions.PersistentDataFileAttachmentPaths` → `BugSplat.CreateFromOptions` resolves each path under `Application.persistentDataPath` and appends `FileInfo`s to `bugSplat.Attachments` (`Runtime/BugSplat.cs`) → `ReportPostOptionsExtensions.SetNullOrEmptyValues` copies that list into `IReportPostOptions.AdditionalAttachments` → `DotNetStandardClient` copies *that* into `ExceptionPostOptions.Attachments`, `MinidumpPostOptions.Attachments` and `FeedbackPostOptions.Attachments`.

**Native** — `AttachNativeLogFile` / `DetachNativeLogFile` → `nativeAttachmentPaths` → `AddNativeAttachment` / `RemoveNativeAttachment` → `_attachNativeLogFile` (macOS, iOS) or `BugSplat_AddAttachment` (Windows), and a no-op on Android.

Nothing reads across. `AddNativeAttachment` has exactly one caller, `AttachNativeLogFile`; `Attachments` has exactly one reader, `SetNullOrEmptyValues`. I also checked that no C# path uploads a native crash report through the managed client at startup — the Windows unsent-report upload happens inside the native library — so there is no case where the managed list reaches a native report by a side door.

One nuance worth recording, because it makes "managed exception reports and feedback" slightly too narrow: the managed list *also* reaches a minidump you upload yourself through the public `Post(FileInfo minidump, …)` overload, since that goes through `MinidumpPostOptions`. The wording below says "reports posted from managed code" and enumerates all three rather than two.

## The changes

**`Documentation~/api.md`** — the options table row now reads:

> Paths to files (relative to Application.persistentDataPath) to attach to reports posted from managed code — exception reports, feedback, and minidumps you post yourself. Native crash reports are assembled by the platform's crash reporter and never see this list; attach files to those with [AttachNativeLogFile](#attaching-files-to-native-crash-reports)

**`Documentation~/api.md`, "Attaching Files to Native Crash Reports"** — the section already stated one direction (`Attachments` never reaches native reports); it now names the options field as the thing that populates `Attachments`, and states the converse:

> The separation runs both ways: a file attached with `AttachNativeLogFile` reaches native crash reports only, and never appears on a managed exception report or a feedback post. Nothing bridges the two lists, so a file you want on both kinds of report has to be registered with both mechanisms.

**`Runtime/Client/BugSplatOptions.cs`** — the tooltip, matching the surrounding style (ASCII only, terminal period, ` - ` rather than an em dash):

> Paths to files (relative to Application.persistentDataPath) to attach to reports posted from managed code - exception reports, feedback, and minidumps you post yourself. Native crash reports are assembled by the platform's crash reporter and never see this list, so attach files to those with AttachNativeLogFile in code.

**`Runtime/BugSplat.cs`** — the XML doc on `Attachments` gained the same caveat. The issue names `Attachments` in its title, and this is the doc a developer sees on hover in an IDE.

### On the tooltip

The issue says the field is "the only option on the asset without one". That was true when it was filed and isn't now — #235 gave every field a tooltip, including this one, carrying the same misleading "upload with each report" wording. So this **rewords the existing tooltip** rather than adding a missing one. The discoverability gap the issue describes is real either way; only the mechanics of the fix changed.

### On the table

I added it. A two-row table in the native-attachments section:

| Mechanism | Reaches | Does not reach |
|---|---|---|
| `Attachments`, `PersistentDataFileAttachmentPaths` | Managed exception reports, feedback, and minidumps you post with `Post(FileInfo)` | Native crash reports |
| `AttachNativeLogFile` | Native crash reports on Windows, macOS, and iOS | Managed exception reports and feedback |

It earns its place: the question that went wrong in the smoke test — "will this file be on the report I'm about to trigger?" — is a lookup, and prose makes you reconstruct the answer from two paragraphs. It sits next to the existing per-platform support table, which answers a different question, and neither duplicates the other.

## Verification

Changes are three doc strings and one attribute string, so there is little to run and nothing whose behavior could have moved. I did confirm the package still compiles rather than assuming: cloned the wired host project, repointed it at this branch's worktree, and ran the PlayMode suite on Unity 6000.3.5f2.

**130 passed / 0 failed**, matching baseline, with zero `error CS` in the editor log and the log confirming the worktree package was the one loaded. That result is a compile check; it does not exercise the documentation.

Not verified, and not verifiable from a docs change: that a native crash on a real device attaches what the table says. The claims come from reading the P/Invoke call sites, and the per-platform support table they restate is pre-existing and unchanged.

## Interaction with #241

#241 changes how rooted paths in `PersistentDataFileAttachmentPaths` resolve — reject them, or accept them as absolute. I deliberately left the existing "(relative to `Application.persistentDataPath`)" parenthetical untouched in all three places, so nothing here contradicts either outcome; whichever way #241 lands, it owns that clause and can amend it without unpicking this. No overlap in edited lines: this PR does not touch the resolution loop in `Runtime/BugSplat.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCtsoKMLq2WeYvsPFivVAA
