### PR TITLE
feat(sample): better sample call stacks

### DIFF
--- a/Samples~/my-unity-crasher/Scripts/CrashScenarios.cs
+++ b/Samples~/my-unity-crasher/Scripts/CrashScenarios.cs
@@ -107,7 +107,7 @@ namespace Crasher
 					Name = "Unhandled managed exception",
 					Expected = "Reported via the log callback. The player keeps running.",
 					RunsInEditor = true,
-					Run = _ => ThrowFromSampleFrames()
+					Run = _ => ThrowFromSampleFrames(ManagedScenario.Unhandled)
 				},
 				new CrashScenario
 				{
@@ -124,7 +124,7 @@ namespace Crasher
 						"once, not twice. Requires Capture Exceptions On Background Threads.",
 					RunsInEditor = true,
 					Run = _ => RunOnBackgroundThread(
-						() => throw new Exception("BugSplat sample: exception on a background thread"))
+						() => ThrowFromSampleFrames(ManagedScenario.BackgroundThread))
 				},
 				new CrashScenario
 				{
@@ -168,15 +168,69 @@ namespace Crasher
 
 		// ---- Managed implementations ----
 
-		static void ThrowFromSampleFrames() => SampleStackFrame0();
-		static void SampleStackFrame0() => SampleStackFrame1();
-		static void SampleStackFrame1() => SampleStackFrame2();
-		static void SampleStackFrame2() => throw new Exception("BugSplat rocks!");
+		/// <summary>
+		/// Which managed row is being run. Threaded through the shared sample frames so the frame that
+		/// actually throws is named after the scenario, putting that name at the top of the reported
+		/// stack. Without it every managed row reports the same SampleStackFrame2 and the rows are
+		/// indistinguishable on the dashboard.
+		/// </summary>
+		enum ManagedScenario
+		{
+			Unhandled,
+			Coroutine,
+			BackgroundThread,
+			UnobservedTask,
+			CaughtAndPosted
+		}
+
+		// NoInlining throughout: these are one-line calls, and IL2CPP inlines them in release builds,
+		// which is exactly where these stacks get read.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowFromSampleFrames(ManagedScenario scenario) => SampleStackFrame0(scenario);
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void SampleStackFrame0(ManagedScenario scenario) => SampleStackFrame1(scenario);
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void SampleStackFrame1(ManagedScenario scenario) => SampleStackFrame2(scenario);
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void SampleStackFrame2(ManagedScenario scenario)
+		{
+			switch (scenario)
+			{
+				case ManagedScenario.Coroutine: ThrowCoroutineException(); break;
+				case ManagedScenario.BackgroundThread: ThrowBackgroundThreadException(); break;
+				case ManagedScenario.UnobservedTask: ThrowUnobservedTaskException(); break;
+				case ManagedScenario.CaughtAndPosted: ThrowCaughtAndPostedException(); break;
+				default: ThrowUnhandledManagedException(); break;
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowUnhandledManagedException() =>
+			throw new Exception("BugSplat sample: unhandled managed exception");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowCoroutineException() =>
+			throw new Exception("BugSplat sample: exception inside a coroutine");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowBackgroundThreadException() =>
+			throw new Exception("BugSplat sample: exception on a background thread");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowUnobservedTaskException() =>
+			throw new Exception("BugSplat sample: unobserved Task exception");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		static void ThrowCaughtAndPostedException() =>
+			throw new Exception("BugSplat sample: caught exception, posted manually");
 
 		static IEnumerator ThrowNextFrame()
 		{
 			yield return null;
-			throw new Exception("BugSplat sample: exception inside a coroutine");
+			ThrowFromSampleFrames(ManagedScenario.Coroutine);
 		}
 
 		/// <summary>
@@ -228,7 +282,7 @@ namespace Crasher
 			{
 				try
 				{
-					throw new Exception("BugSplat sample: unobserved Task exception");
+					ThrowFromSampleFrames(ManagedScenario.UnobservedTask);
 				}
 				finally
 				{
@@ -242,7 +296,7 @@ namespace Crasher
 		{
 			try
 			{
-				ThrowFromSampleFrames();
+				ThrowFromSampleFrames(ManagedScenario.CaughtAndPosted);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
## Why

Four of the five MANAGED rows produce stacks you cannot tell apart on the dashboard. "Unhandled managed exception" and "Caught exception, posted manually" both throw from the same shared `SampleStackFrame2` with the message `BugSplat rocks!`. The coroutine, background-thread and unobserved-`Task` rows throw from compiler-generated lambdas — `<>c.<BuildManaged>b__4_0`, `<StartFaultedTask>b__…` — which name neither the scenario nor anything a reader recognizes.

Testing a crash reporter means running every row and then finding each one on the dashboard. That is guesswork today.

## How

A `ManagedScenario` enum threads through the shared frames, and the last frame switches on it to call a method named after the row:

```
ThrowFromSampleFrames(scenario)
  → SampleStackFrame0(scenario)
  → SampleStackFrame1(scenario)
  → SampleStackFrame2(scenario)      // switch picks the throwing method
       → ThrowUnobservedTaskException()   ← top of the reported stack
```

The scenario name ends up at the **top** of the stack, where the crashing frame is shown, while the shared depth beneath it is kept. Each throwing method carries a matching message, so the dashboard titles differ as well as the stacks.

All five rows now route through the shared frames — including the three that previously threw inline. The faulted `Task` still throws inside its existing `try`, so the `finally` that sets `faultedTaskThrew` is unaffected.

Every link carries `[MethodImpl(MethodImplOptions.NoInlining)]`. These are one-line static calls that IL2CPP will inline in release builds, which is exactly where these stacks get read; without it both the depth and the scenario name disappear from a built player.

## Result

```
Exception: BugSplat sample: unobserved Task exception
  at Crasher.CrashScenarios.ThrowUnobservedTaskException ()
  at Crasher.CrashScenarios.SampleStackFrame2 (ManagedScenario scenario)
  at Crasher.CrashScenarios.SampleStackFrame1 (ManagedScenario scenario)
  at Crasher.CrashScenarios.SampleStackFrame0 (ManagedScenario scenario)
  at Crasher.CrashScenarios.ThrowFromSampleFrames (ManagedScenario scenario)
  at Crasher.CrashScenarios+<>c.<StartFaultedTask>b__…
```

`BugSplat rocks!` is replaced by a message naming the row.

## Verification

- `mcs --parse` clean.
- [ ] Editor: all five MANAGED rows report, each with its own top frame and message.
- [ ] IL2CPP player: the five frames survive — this is what `NoInlining` is protecting, and the only way to prove it.

Sample-only; no runtime or package code is touched. `Samples~` is invisible to Unity, so an existing project sees this after re-importing the sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bapaeRsoZPuK3jjtdk51V